### PR TITLE
Many changes & Additions

### DIFF
--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -21,6 +21,59 @@ namespace vMenuClient
         public CommonFunctions()
         {
             Tick += OnTick;
+            Tick += ManageVehicleOptionsMenu;
+        }
+
+        private async Task ManageVehicleOptionsMenu()
+        {
+            if (MainMenu.VehicleOptionsMenu == null)
+            {
+                await Delay(0);
+            }
+            else
+            {
+                // check to see if the vehicle options menu exists but the player is not inside a vehicle.
+                if (MainMenu.VehicleOptionsMenu.vehicleModMenu != null && !IsPedInAnyVehicle(PlayerPedId(), false))
+                {
+                    // If the vehicle mod submenu is open, close it.
+                    if (MainMenu.VehicleOptionsMenu.vehicleModMenu.Visible)
+                    {
+                        MainMenu.VehicleOptionsMenu.vehicleModMenu.GoBack();
+                        Notify.Error("You must be inside a vehicle to use this menu.");
+                    }
+                    // If the vehicle liveries submenu is open, close it.
+                    if (MainMenu.VehicleOptionsMenu.vehicleLiveries.Visible)
+                    {
+                        MainMenu.VehicleOptionsMenu.vehicleLiveries.GoBack();
+                        Notify.Error("You must be inside a vehicle to use this menu.");
+                    }
+                    // If the vehicle colors submenu is open, close it.
+                    if (MainMenu.VehicleOptionsMenu.vehicleColors.Visible)
+                    {
+                        MainMenu.VehicleOptionsMenu.vehicleColors.GoBack();
+                        Notify.Error("You must be inside a vehicle to use this menu.");
+                    }
+                    // If the vehicle doors submenu is open, close it.
+                    if (MainMenu.VehicleOptionsMenu.vehicleDoorsMenu.Visible)
+                    {
+                        MainMenu.VehicleOptionsMenu.vehicleDoorsMenu.GoBack();
+                        Notify.Error("You must be inside a vehicle to use this menu.");
+                    }
+                    // If the vehicle windows submenu is open, close it.
+                    if (MainMenu.VehicleOptionsMenu.vehicleWindowsMenu.Visible)
+                    {
+                        MainMenu.VehicleOptionsMenu.vehicleWindowsMenu.GoBack();
+                        Notify.Error("You must be inside a vehicle to use this menu.");
+                    }
+                    // If the vehicle extras submenu is open, close it.
+                    if (MainMenu.VehicleOptionsMenu.vehicleComponents.Visible)
+                    {
+                        MainMenu.VehicleOptionsMenu.vehicleComponents.GoBack();
+                        Notify.Error("You must be inside a vehicle to use this menu.");
+                    }
+
+                }
+            }
         }
 
         #region OnTick for spectate handling
@@ -557,6 +610,45 @@ namespace vMenuClient
             }
 
         }
+        #endregion
+
+        #region ToProperString()
+        /// <summary>
+        /// Converts a PascalCaseString to a Propper Case String.
+        /// </summary>
+        /// <param name="inputString"></param>
+        /// <returns></returns>
+        public string ToProperString(string inputString)
+        {
+            var outputString = "";
+            var prevUpper = true;
+            foreach (char c in inputString)
+            {
+                if (char.IsLetter(c) && c != ' ' && c == char.Parse(c.ToString().ToUpper()))
+                {
+                    if (prevUpper)
+                    {
+                        outputString += $"{c.ToString()}";
+                    }
+                    else
+                    {
+                        outputString += $" {c.ToString()}";
+                    }
+                    prevUpper = true;
+                }
+                else
+                {
+                    prevUpper = false;
+                    outputString += c.ToString();
+                }
+            }
+            while (outputString.IndexOf("  ") != -1)
+            {
+                outputString = outputString.Replace("  ", " ");
+            }
+            return outputString;
+        }
+
         #endregion
 
         /// <summary>

--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -18,8 +18,9 @@ namespace vMenuClient
         public static Subtitles Subtitle { get; } = new Subtitles();
 
         public static MenuPool Mp { get; } = new MenuPool();
-        public static System.Drawing.PointF MenuPosition { get; } = new System.Drawing.PointF(CitizenFX.Core.UI.Screen.Resolution.Width - 465f, 45f);
-        public static UIResRectangle BannerSprite { get; } = new UIResRectangle(new System.Drawing.PointF(0f, 0f), new System.Drawing.SizeF(0f, 0f), UnknownColors.SlateGray);
+        public static System.Drawing.PointF MenuPosition { get; } = new System.Drawing.PointF(CitizenFX.Core.UI.Screen.Resolution.Width - 800f, 45f);
+        //public static System.Drawing.PointF MenuPosition { get; } = new System.Drawing.PointF(0f, 0f);
+        public static UIResRectangle BannerSprite { get; } = new UIResRectangle(new System.Drawing.PointF(0f, 0f), new System.Drawing.SizeF(1920f, 1080f), UnknownColors.SlateGray);
 
         private bool firstTick = true;
         private bool setupComplete = false;
@@ -117,13 +118,13 @@ namespace vMenuClient
                 }
 
                 // Create the main menu.
-                Menu = new UIMenu(GetPlayerName(PlayerId()), "Main Menu", MenuPosition);
+                Menu = new UIMenu(GetPlayerName(PlayerId()), "Main Menu");
 
                 // Add the main menu to the menu pool.
                 Mp.Add(Menu);
 
                 Menu.RefreshIndex();
-                Menu.ScaleWithSafezone = false;
+                Menu.ScaleWithSafezone = true;
 
                 Menu.UpdateScaleform();
                 Menu.MouseControlsEnabled = false;
@@ -232,11 +233,12 @@ namespace vMenuClient
                 Menu.UpdateScaleform();
 
                 // Set the banner globally.
-                Mp.SetBannerType(BannerSprite);
+                //Mp.SetBannerType(BannerSprite);
                 // Globally disable the native ui controls disabling.
                 Mp.ControlDisablingEnabled = false;
                 // Globally disable the "mouse edge" feature.
                 Mp.MouseEdgeEnabled = false;
+                //Mp.WidthOffset = 50;
             }
             #endregion
 
@@ -353,6 +355,7 @@ namespace vMenuClient
 
                 // Process all menus in the menu pool (displays them when they're active).
                 Mp.ProcessMenus();
+                Mp.WidthOffset = 50;
 
             }
 

--- a/vMenu/menus/About.cs
+++ b/vMenu/menus/About.cs
@@ -20,9 +20,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "About vMenu", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "About vMenu")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
 

--- a/vMenu/menus/MiscSettings.cs
+++ b/vMenu/menus/MiscSettings.cs
@@ -20,9 +20,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "Misc Settings", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Misc Settings")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
             UIMenuItem tptowp = new UIMenuItem("Teleport To WayPoint", "Teleport to the waypoint on your map.");

--- a/vMenu/menus/OnlinePlayers.cs
+++ b/vMenu/menus/OnlinePlayers.cs
@@ -24,9 +24,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "Online Players", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Online Players")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
             UpdatePlayerlist();
@@ -58,13 +58,11 @@ namespace vMenuClient
                         //Notify.Custom(int.Parse(item.Description.Substring(1, 2).ToString()).ToString());
 
                         // Create the menu for the player.
-                        UIMenu PlayerMenu = new UIMenu(player.Name, "[" + (player.Handle < 10 ? "0" : "") + player.Handle + "] " + player.Name + " (Server ID: " + player.ServerId + ")", MainMenu.MenuPosition)
-                        {
-                            ScaleWithSafezone = false
-                        };
+                        UIMenu PlayerMenu = new UIMenu(player.Name, "[" + (player.Handle < 10 ? "0" : "") + player.Handle + "] " + player.Name + " (Server ID: " + player.ServerId + ")");
                         PlayerMenu.MouseControlsEnabled = false;
+                        PlayerMenu.SetMenuWidthOffset(50);
 
-                        PlayerMenu.SetBannerType(MainMenu.BannerSprite);
+                        //PlayerMenu.SetBannerType(MainMenu.BannerSprite);
                         PlayerMenu.ControlDisablingEnabled = false;
                         PlayerMenu.MouseEdgeEnabled = false;
 

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -20,9 +20,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "Player Appearance", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Player Appearance")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
         }

--- a/vMenu/menus/PlayerOptions.cs
+++ b/vMenu/menus/PlayerOptions.cs
@@ -32,9 +32,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "Player Options", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Player Options")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
 

--- a/vMenu/menus/TimeOptions.cs
+++ b/vMenu/menus/TimeOptions.cs
@@ -20,9 +20,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "Time Options", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Time Options")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
         }

--- a/vMenu/menus/VehicleSpawner.cs
+++ b/vMenu/menus/VehicleSpawner.cs
@@ -22,9 +22,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "Vehicle Spawner", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Vehicle Spawner")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
             UIMenuItem spawnByName = new UIMenuItem("Spawn Vehicle By Name", "Enter a vehicle model name to spawn.");

--- a/vMenu/menus/VoiceChat.cs
+++ b/vMenu/menus/VoiceChat.cs
@@ -20,9 +20,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "VoiceChat Settings", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Voice Chat Settings")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
         }

--- a/vMenu/menus/WeaponOptions.cs
+++ b/vMenu/menus/WeaponOptions.cs
@@ -20,9 +20,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "Weapon Options", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Weapon Options")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
         }

--- a/vMenu/menus/WeatherOptions.cs
+++ b/vMenu/menus/WeatherOptions.cs
@@ -20,9 +20,9 @@ namespace vMenuClient
         private void CreateMenu()
         {
             // Create the menu.
-            menu = new UIMenu(GetPlayerName(PlayerId()), "Weather Options", MainMenu.MenuPosition)
+            menu = new UIMenu(GetPlayerName(PlayerId()), "Weather Options")//, MainMenu.MenuPosition)
             {
-                ScaleWithSafezone = false,
+                //ScaleWithSafezone = false,
                 MouseEdgeEnabled = false
             };
         }


### PR DESCRIPTION
# Many changes & Additions:

- When not inside a vehicle, and you (try to) open or already have opened one of the following (sub)menus, they will automatically close: vehicle mod menu, vehicle liveries menu, vehicle extras/components menu, vehicle colors menu, vehicle doors menu, vehicle windows menu. This can easilly be expanded to any future updates to work with other menus as well.

- Added a ToProperString() function that converts an input string (PascalCasedString) into a regular (Proper Case String), it's now only used for converting vehicle mod type names (SideSkirt > Side Skirt, etc), but it is available for any future needs. Access it using `cf.ToProperCase(string inputString)`

- Increased the width of the menu, unfortunately this also means that custom headers no longer work, also the menu had to be moved back to the left because the menu title did not move with the menu once the menu width has changed. Stupid bugs, but for now I can't be bothered trying to fix this in NativeUI, as it will be quite some work getting this fixed. The size increase was a must because the vehicle mod options clipped outside of the menu bounds (due to very long names). A positive effect is that the menu now scales with the safe zone size again. Previously this was impossible to achieve.

- All vehicle mod options (besides the window tint) are now available. Needs to be tested to confirm it's working on all vehicles though.