### PR TITLE
Loading & Saving Vehicles!

### DIFF
--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -39,6 +39,7 @@ namespace vMenuClient
         public static MiscSettings MiscSettingsMenu { get; private set; }
         public static VoiceChat VoiceChatSettingsMenu { get; private set; }
         public static About AboutMenu { get; private set; }
+        //public StorageManager Sm { get; } = new StorageManager();
 
         public static Dictionary<string, bool> Permissions { get; private set; } = new Dictionary<string, bool>();
 
@@ -110,6 +111,9 @@ namespace vMenuClient
                 }
             }
             #endregion
+
+
+            //Sm.SaveDictionary("testpermissions", Permissions);
 
             setupComplete = true;
         }

--- a/vMenu/StorageManager.cs
+++ b/vMenu/StorageManager.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CitizenFX.Core;
+using static CitizenFX.Core.Native.API;
+
+namespace vMenuClient
+{
+
+    public class StorageManager : BaseScript
+    {
+        //public StorageManager()
+        //{
+        //    //TriggerEvent("chatMessage", SaveDictionary("vehicle1", new Dictionary<string, string>() { ["engine"] = "4"}, true).ToString());
+        //    //DeleteResourceKvp("vehicle1");
+
+        //}
+
+
+        /// <summary>
+        /// Save a dictionary to the client's storage.
+        /// </summary>
+        /// <param name="saveName">The key used to save this dictionary.</param>
+        /// <param name="data">The dictionary to save.</param>
+        /// <param name="overrideExistingData">If the key/dictionary already exists, do you want to override it?</param>
+        /// <returns>True when the save was successful, false if it was not.</returns>
+        public bool SaveDictionary(string saveName, Dictionary<string, string> data, bool overrideExistingData)
+        {
+            // If the savename doesn't exist yet or we're allowed to override it.
+            if (GetResourceKvpString(saveName) == null || overrideExistingData)
+            {
+                // Get the json string from the dictionary.
+                string jsonString = MainMenu.cf.DictionaryToJson(data);
+
+                // Save the kvp.
+                SetResourceKvp(saveName, jsonString);
+
+                // Return true if the kvp was set successfully, false if it wasn't set successfully.
+                return GetResourceKvpString(saveName) == jsonString;
+            }
+            // If the data already exists and we are not allowed to override it.
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get a saved dictionary.
+        /// </summary>
+        /// <param name="name">The key for the dictionary to get.</param>
+        /// <returns>The requested dictionary.</returns>
+        public Dictionary<string, string> GetSavedDictionary(string name)
+        {
+            string json = GetResourceKvpString(name);
+            var dict = MainMenu.cf.JsonToDictionary(json);
+            return dict ?? new Dictionary<string, string>();
+        }
+
+        public void DeleteSavedDictionary(string saveName)
+        {
+            DeleteResourceKvp(saveName);
+        }
+
+
+
+    }
+}

--- a/vMenu/menus/SavedVehicles.cs
+++ b/vMenu/menus/SavedVehicles.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using CitizenFX.Core;
 using static CitizenFX.Core.Native.API;
 using NativeUI;
-using Newtonsoft.Json;
 
 namespace vMenuClient
 {
@@ -17,6 +16,7 @@ namespace vMenuClient
         private Notification Notify = MainMenu.Notify;
         private Subtitles Subtitle = MainMenu.Subtitle;
         private CommonFunctions cf = MainMenu.cf;
+        private Dictionary<string, Dictionary<string, string>> SavedVehiclesDict;
 
         private void CreateMenu()
         {
@@ -24,9 +24,89 @@ namespace vMenuClient
             menu = new UIMenu(GetPlayerName(PlayerId()), "Saved Vehicles")
             {
                 MouseEdgeEnabled = false
-
             };
+
+            UIMenuItem saveVeh = new UIMenuItem("Save Current Vehicle");
+            menu.AddItem(saveVeh);
+            menu.OnItemSelect += (sender, item, index) =>
+            {
+                if (item == saveVeh)
+                {
+                    cf.SaveVehicle();
+                }
+            };
+
+            UIMenu savedVehicles = new UIMenu("Saved Vehicles", "Select a vehicle to spawn");
+            savedVehicles.ControlDisablingEnabled = false;
+            savedVehicles.MouseControlsEnabled = false;
+            savedVehicles.MouseEdgeEnabled = false;
+            UIMenuItem savedVehiclesBtn = new UIMenuItem("Spawn Saved Vehicle", "Spawn a saved vehicle from the list.");
+            menu.AddItem(savedVehiclesBtn);
+            menu.BindMenuToItem(savedVehicles, savedVehiclesBtn);
+
+            menu.OnItemSelect += (sender, item, index) =>
+            {
+                if (item == savedVehiclesBtn)
+                {
+                    savedVehicles.MenuItems.Clear();
+
+                    SavedVehiclesDict = cf.GetSavedVehicleList();
+
+                    foreach (KeyValuePair<string, Dictionary<string, string>> savedVehicle in SavedVehiclesDict)
+                    {
+                        UIMenuItem vehBtn = new UIMenuItem(savedVehicle.Key.Substring(4), "Click to spawn this saved vehicle.");
+                        vehBtn.SetRightLabel($"({savedVehicle.Value["name"]})");
+                        savedVehicles.AddItem(vehBtn);
+                    }
+                    savedVehicles.OnItemSelect += (sender2, item2, index2) =>
+                    {
+                        var vehInfo = SavedVehiclesDict["veh_" + item2.Text];
+                        var model = vehInfo["model"];
+                        cf.SpawnVehicle((uint)Int64.Parse(model), MainMenu.VehicleSpawnerMenu.SpawnInVehicle, MainMenu.VehicleSpawnerMenu.ReplaceVehicle);
+                    };
+                }
+            };
+
+            UIMenu deleteSavedVehicles = new UIMenu("Saved Vehicles", "~r~Delete saved vehicle");
+            deleteSavedVehicles.ControlDisablingEnabled = false;
+            deleteSavedVehicles.MouseControlsEnabled = false;
+            deleteSavedVehicles.MouseEdgeEnabled = false;
+            UIMenuItem deleteSavedVehiclesBtn = new UIMenuItem("~r~Delete Saved Vehicle", "~r~Delete a saved vehicle.");
+            deleteSavedVehiclesBtn.SetLeftBadge(UIMenuItem.BadgeStyle.Alert);
+            menu.AddItem(deleteSavedVehiclesBtn);
+            menu.BindMenuToItem(deleteSavedVehicles, deleteSavedVehiclesBtn);
+
+            menu.OnItemSelect += (sender, item, index) =>
+            {
+                if (item == deleteSavedVehiclesBtn)
+                {
+                    deleteSavedVehicles.MenuItems.Clear();
+
+                    SavedVehiclesDict = cf.GetSavedVehicleList();
+
+                    foreach (KeyValuePair<string, Dictionary<string, string>> savedVehicle in SavedVehiclesDict)
+                    {
+                        UIMenuItem vehBtn = new UIMenuItem(savedVehicle.Key.Substring(4), "Are you sure you want to delete this saved vehicle? This action cannot be undone!");
+                        vehBtn.SetLeftBadge(UIMenuItem.BadgeStyle.Alert);
+                        vehBtn.SetRightLabel($"({savedVehicle.Value["name"]})");
+                        deleteSavedVehicles.AddItem(vehBtn);
+                    }
+                    deleteSavedVehicles.OnItemSelect += (sender2, item2, index2) =>
+                    {
+                        var vehDictName = "veh_" + item2.Text;
+                        new StorageManager().DeleteSavedDictionary(vehDictName);
+                        deleteSavedVehicles.GoBack();
+                    };
+                }
+            };
+
+
+
+            MainMenu.Mp.Add(savedVehicles);
+            MainMenu.Mp.Add(deleteSavedVehicles);
+
             menu.MouseControlsEnabled = false;
+
         }
 
         /// <summary>

--- a/vMenu/packages.config
+++ b/vMenu/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CitizenFX.Core" version="1.3.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
 </packages>

--- a/vMenu/vMenuClient.csproj
+++ b/vMenu/vMenuClient.csproj
@@ -37,9 +37,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\NativeUI.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -69,6 +66,7 @@
     <Compile Include="PedScenarios.cs" />
     <Compile Include="menus\PlayerOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StorageManager.cs" />
     <Compile Include="VehicleData.cs" />
     <Compile Include="Vehicles.cs" />
   </ItemGroup>

--- a/vMenuServer/vMenuServer.csproj
+++ b/vMenuServer/vMenuServer.csproj
@@ -56,11 +56,11 @@
     <Compile Include="UpdateChecker.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="config\permissions.cfg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CustomToolNamespace>config</CustomToolNamespace>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Saving and loading saved vehicles now works(-ish). Currently only the model display name, model hash and a custom save name are saved, can be loaded and can be deleted. The vehicle mods, colors, liveries and other customization features are not yet saved. But that's very easy to add because the base for saving and loading (dynamically) is ready, albeit a bit hacky.

I've made a custom framework for saving and loading any dictionary, so this is is not limited to just saving vehicles. Everything will be able to be saved and loaded using this framework. There's just one downside: you can only save in this format (key=string, value=Dictionary<string,string>), to use it, call: 
```cs
StorageManager sm = new StorageManager();

string dataSaveName = "veh_my vehicle";
// data = dictionary containing all key/value pairs (strings)
bool overrideExistingData = false;

// Returns true if save was successful, false if it wasn't.
bool result = sm.SaveDictionary(dataSaveName, data, overrideExistingData); 
```

To load a dictionary use this:
```cs
StorageManager sm = new StorageManager();

Dictionary<string, string> data;
data = sm.GetSavedDictionary("veh_my vehicle");
```

To delete a dictionary:
```cs
StorageManager sm = new StorageManager();

sm.DeleteSavedDictionary("veh_my vehicle");
```
