### PR TITLE
Fixed a critical permissions bug

### DIFF
--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -82,6 +82,10 @@ namespace vMenuClient
             // Loop through the dynamic object and get the keys and values.
             foreach (dynamic permission in dict)
             {
+                if (DebugMode)
+                {
+                    Cf.Log($"{permission.Key.ToString()} = {permission.Value.ToString()}");
+                }
                 // Add the new permission to the dictionary.
                 PermissionsManager.SetPermission(permission.Key.ToString(), permission.Value);
             }

--- a/vMenu/PermissionsManager.cs
+++ b/vMenu/PermissionsManager.cs
@@ -161,18 +161,18 @@ namespace vMenuClient
         {
             if (perms.Contains("Everything"))
             {
+                if (MainMenu.DebugMode)
+                {
+                    MainMenu.Cf.Log("Everything allowed, breaking.");
+                }
                 return true;
             }
             else
             {
                 var allowed = false;
-                foreach (var p in Enum.GetNames(typeof(Permission)))
+                if (perms.Contains(permission.ToString().Substring(0,2) + "All"))
                 {
-                    if (perms.Contains(p.Substring(0, 2) + "All"))
-                    {
-                        allowed = true;
-                        break;
-                    }
+                    allowed = true;
                 }
 
                 if (!allowed)


### PR DESCRIPTION
# Fixed a critical permissions bug
If you used any `.All` permissions, everyone would get ALL permissions. This is now solved!