### PR TITLE
New features, bug-fixes and removed/improved some things.

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -135,7 +135,6 @@
 
 ## Weather Options
 
-
 |Permission|Description|Default[\*](#global-permissions)|
 |:-|:-|:-|
 |`vMenu.WeatherOptions.Menu`|Grants access to the Weather Options Menu.|Denied[\*\*](#global-permissions)|
@@ -157,6 +156,8 @@
 |`vMenu.WeaponOptions.RemoveAll`|Allows you to use the `Remove All Weapons` button.|Allowed|
 |`vMenu.WeaponOptions.UnlimitedAmmo`|Allows you to enable/disable unlimited ammo.|Allowed|
 |`vMenu.WeaponOptions.NoReload`|Allows you to enable/disable no-reload.|Allowed|
+|`vMenu.WeaponOptions.Spawn`|Allows you to spawn/remove ANY weapon, denying this will still grant access to the customization options for each weapon. This also allows players to spawn addon weapons.|Allowed|
+|`vMenu.WeaponOptions.SetAllAmmo`|Allows you to bulk set the ammo count in all currently equipped weapons.|Allowed|
 
 ## Misc Settings
 **The `Save Personal Settings` option in the Misc Settings Menu is always allowed, so there's no permission line for that.**

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -82,6 +82,7 @@
 |`vMenu.VehicleSpawner.Menu`|Grants access to the Vehicle Spawner Menu.|Allowed|
 |`vMenu.VehicleSpawner.All`|Allows you to spawn **ANY** vehicle.|Denied|
 |`vMenu.VehicleSpawner.SpawnByName`|Allows you to enter a **custom vehicle name** to spawn[\*\*\*](#global-permissions).|Allowed|
+|`vMenu.VehicleSpawner.Addon`|Allows you to spawn a vehicle from the Addon Vehicles list (requires vMenu v1.0.7+).|Allowed|
 |`vMenu.VehicleSpawner.Compacts`|Allows you to spawn a vehicle from this category.|Allowed|
 |`vMenu.VehicleSpawner.Sedans`|Allows you to spawn a vehicle from this category.|Allowed|
 |`vMenu.VehicleSpawner.SUVs`|Allows you to spawn a vehicle from this category.|Allowed|

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1500,6 +1500,22 @@ namespace vMenuClient
                 Notify.Error(CommonErrors.InvalidModel);
             }
         }
+
+        /// <summary>
+        /// Set the player model by asking for user input.
+        /// </summary>
+        public async void SpawnPedByName()
+        {
+            string input = await GetUserInput("Enter Ped Model Name", "", 30) ?? "NULL";
+            if (input != "NULL")
+            {
+                SetPlayerSkin(GetHashKey(input));
+            }
+            else
+            {
+                Notify.Error(CommonErrors.InvalidModel);
+            }
+        }
         #endregion
 
         #region Save Ped Model + Customizations
@@ -1716,6 +1732,61 @@ namespace vMenuClient
             }
             return output;
 
+        }
+        #endregion
+
+        #region Weapon Options
+        /// <summary>
+        /// Set the ammo for all weapons in inventory to the custom amount entered by the user.
+        /// </summary>
+        public async void SetAllWeaponsAmmo()
+        {
+            int ammo = 100;
+            string inputAmmo = await GetUserInput("Enter Ammo Amount", "100") ?? "NULL";
+
+            if (inputAmmo != "NULL")
+            {
+                ammo = int.Parse(inputAmmo);
+                Ped ped = Game.PlayerPed;
+                foreach (var wp in ValidWeapons.Weapons)
+                {
+                    if (ped.Weapons.HasWeapon((WeaponHash)wp.Value))
+                    {
+                        SetPedAmmo(ped.Handle, wp.Value, ammo);
+                    }
+                }
+            }
+            else
+            {
+                Notify.Error("You did not enter a valid ammo count.");
+            }
+        }
+
+        /// <summary>
+        /// Spawn a weapon by asking the player for the weapon name.
+        /// </summary>
+        public async void SpawnCustomWeapon()
+        {
+            int ammo = 900;
+            string inputName = await GetUserInput("Enter Weapon Model Name", "", 30) ?? "NULL";
+            if (inputName != "NULL")
+            {
+                var model = (uint)GetHashKey(inputName.ToUpper());
+                
+                if (IsWeaponValid(model))
+                {
+                    GiveWeaponToPed(PlayerPedId(), model, ammo, false, true);
+                    Notify.Success("Added weapon to inventory.");
+                }
+                else
+                {
+                    Notify.Error($"This ({inputName.ToString()}) is not a valid weapon model name, or the model hash ({model.ToString()}) could not be found in the game files.");
+                }
+            }
+            else
+            {
+                Notify.Error($"This ({inputName.ToString()}) is not a valid weapon model name.");
+            }
         }
         #endregion
     }

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -961,10 +961,11 @@ namespace vMenuClient
         public async Task<string> GetUserInput(string windowTitle = null, string defaultText = null, int maxInputLength = 20)
         {
             // Create the window title string.
-            AddTextEntry("FMMC_KEY_TIP1", $"{windowTitle ?? "Enter"}:   (MAX {maxInputLength.ToString()} CHARACTERS)");
+            var spacer = "\t";
+            AddTextEntry($"{GetCurrentResourceName().ToUpper()}_WINDOW_TITLE", $"{windowTitle ?? "Enter"}:{spacer}(MAX {maxInputLength.ToString()} Characters)");
 
             // Display the input box.
-            DisplayOnscreenKeyboard(1, "FMMC_KEY_TIP1", "", defaultText ?? "", "", "", "", maxInputLength);
+            DisplayOnscreenKeyboard(1, $"{GetCurrentResourceName().ToUpper()}_WINDOW_TITLE", "", defaultText ?? "", "", "", "", maxInputLength);
             await Delay(0);
             // Wait for a result.
             while (true)

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1454,9 +1454,18 @@ namespace vMenuClient
         /// Sets the player's model to the provided modelName.
         /// </summary>
         /// <param name="modelHash">The model hash.</param>
-        public async void SetPlayerSkin(int modelHash, Dictionary<string, string> pedCustomizationOptions = null)
+        public void SetPlayerSkin(int modelHash, Dictionary<string, string> pedCustomizationOptions = null)
         {
-            uint model = (uint)modelHash;
+            SetPlayerSkin((uint)modelHash, pedCustomizationOptions);
+        }
+
+        /// <summary>
+        /// Sets the player's model to the provided modelHash.
+        /// </summary>
+        /// <param name="modelHash">The model hash.</param>
+        public async void SetPlayerSkin(uint modelHash, Dictionary<string, string> pedCustomizationOptions = null)
+        {
+            uint model = modelHash;
             if (IsModelInCdimage(model))
             {
                 await SaveWeaponLoadout();
@@ -1492,7 +1501,6 @@ namespace vMenuClient
                         }
                     }
                 }
-
                 RestoreWeaponLoadout();
             }
             else
@@ -1772,7 +1780,7 @@ namespace vMenuClient
             if (inputName != "NULL")
             {
                 var model = (uint)GetHashKey(inputName.ToUpper());
-                
+
                 if (IsWeaponValid(model))
                 {
                     GiveWeaponToPed(PlayerPedId(), model, ammo, false, true);

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -18,6 +18,9 @@ namespace vMenuClient
         private string currentScenario = "";
         private Vehicle previousVehicle;
         private StorageManager sm = new StorageManager();
+
+        public bool driveToWpTaskActive = false;
+        public bool driveWanderTaskActive = false;
         #endregion
 
         /// <summary>
@@ -119,7 +122,23 @@ namespace vMenuClient
         /// </summary>
         public void DriveToWp()
         {
-            throw new NotImplementedException();
+            if (driveWanderTaskActive || driveToWpTaskActive)
+            {
+                ClearPedTasks(PlayerPedId());
+                driveWanderTaskActive = false;
+                driveToWpTaskActive = false;
+            }
+            else
+            {
+                driveToWpTaskActive = true;
+                var waypoint = World.WaypointPosition;
+                var veh = GetVehicle();
+                var model = (uint)GetEntityModel(veh);
+                SetDriverAbility(PlayerPedId(), 100f);
+                SetDriverAggressiveness(PlayerPedId(), 0f);
+                //TaskVehicleDriveToCoord(PlayerPedId(), veh, waypoint.X, waypoint.Y, waypoint.Z, GetVehicleModelMaxSpeed(model), 0, model, 1074528293, 12f, 0f);
+                TaskVehicleDriveToCoordLongrange(PlayerPedId(), veh, waypoint.X, waypoint.Y, waypoint.Z, GetVehicleModelMaxSpeed(model), 1074528293, 10f);
+            }
         }
 
         /// <summary>
@@ -127,7 +146,21 @@ namespace vMenuClient
         /// </summary>
         public void DriveWander()
         {
-            throw new NotImplementedException();
+            if (driveWanderTaskActive || driveToWpTaskActive)
+            {
+                ClearPedTasks(PlayerPedId());
+                driveWanderTaskActive = false;
+                driveToWpTaskActive = false;
+            }
+            else
+            {
+                driveWanderTaskActive = true;
+                var veh = GetVehicle();
+                var model = (uint)GetEntityModel(veh);
+                SetDriverAbility(PlayerPedId(), 100f);
+                SetDriverAggressiveness(PlayerPedId(), 0f);
+                TaskVehicleDriveWander(PlayerPedId(), veh, GetVehicleModelMaxSpeed(model), 1074528293);
+            }
         }
         #endregion
 

--- a/vMenu/EventManager.cs
+++ b/vMenu/EventManager.cs
@@ -73,12 +73,11 @@ namespace vMenuClient
             }
             else if (addonType == "peds")
             {
-                // Todo
+                PlayerAppearance.AddonPeds = models;
                 MainMenu.addonPedsLoaded = true;
             }
             else if (addonType == "weapons")
             {
-                // Todo
                 WeaponOptions.AddonWeapons = models;
                 MainMenu.addonWeaponsLoaded = true;
             }

--- a/vMenu/EventManager.cs
+++ b/vMenu/EventManager.cs
@@ -35,6 +35,7 @@ namespace vMenuClient
             EventHandlers.Add("vMenu:SetClouds", new Action<float, string>(SetClouds));
             EventHandlers.Add("vMenu:SetTime", new Action<int, int, bool>(SetTime));
             EventHandlers.Add("vMenu:SetOptions", new Action<dynamic>(UpdateSettings));
+            EventHandlers.Add("vMenu:SetupAddonCars", new Action<string, dynamic>(SetAddonModels));
 
             Tick += WeatherSync;
             Tick += TimeSync;
@@ -48,6 +49,27 @@ namespace vMenuClient
         private void UpdatePermissions(dynamic permissions)
         {
             MainMenu.SetPermissions(permissions);
+        }
+
+        private void SetAddonModels(string addonType, dynamic addons)
+        {
+            Dictionary<string, uint> models = new Dictionary<string, uint>();
+            foreach (var addon in addons)
+            {
+                string modelName = addon.ToString();
+                uint modelHash = (uint)GetHashKey(modelName);
+
+                if (!models.ContainsKey(modelName))
+                {
+                    models.Add(modelName, modelHash);
+                }
+            }
+            if (addonType == "vehicles")
+            {
+                VehicleSpawner.AddonVehicles = models;
+                MainMenu.addonCarsLoaded = true;
+            }
+
         }
 
         /// <summary>

--- a/vMenu/EventManager.cs
+++ b/vMenu/EventManager.cs
@@ -35,7 +35,9 @@ namespace vMenuClient
             EventHandlers.Add("vMenu:SetClouds", new Action<float, string>(SetClouds));
             EventHandlers.Add("vMenu:SetTime", new Action<int, int, bool>(SetTime));
             EventHandlers.Add("vMenu:SetOptions", new Action<dynamic>(UpdateSettings));
+            EventHandlers.Add("vMenu:SetupAddonPeds", new Action<string, dynamic>(SetAddonModels));
             EventHandlers.Add("vMenu:SetupAddonCars", new Action<string, dynamic>(SetAddonModels));
+            EventHandlers.Add("vMenu:SetupAddonWeapons", new Action<string, dynamic>(SetAddonModels));
 
             Tick += WeatherSync;
             Tick += TimeSync;
@@ -68,6 +70,17 @@ namespace vMenuClient
             {
                 VehicleSpawner.AddonVehicles = models;
                 MainMenu.addonCarsLoaded = true;
+            }
+            else if (addonType == "peds")
+            {
+                // Todo
+                MainMenu.addonPedsLoaded = true;
+            }
+            else if (addonType == "weapons")
+            {
+                // Todo
+                WeaponOptions.AddonWeapons = models;
+                MainMenu.addonWeaponsLoaded = true;
             }
 
         }

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -188,6 +188,14 @@ namespace vMenuClient
                     // Manage player frozen.
                     FreezeEntityPosition(PlayerPedId(), MainMenu.PlayerOptionsMenu.PlayerFrozen && cf.IsAllowed(Permission.POFreeze));
                 }
+
+
+                if (MainMenu.Cf.driveToWpTaskActive && !Game.IsWaypointActive)
+                {
+                    ClearPedTasks(PlayerPedId());
+                    Notify.Custom("Destination reached, the car will now stop driving!");
+                    MainMenu.Cf.driveToWpTaskActive = false;
+                }
             }
             else
             {

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -121,7 +121,8 @@ namespace vMenuClient
                 SetEntityInvincible(PlayerPedId(), MainMenu.PlayerOptionsMenu.PlayerGodMode && cf.IsAllowed(Permission.POGod));
 
                 // Manage invisibility.
-                SetEntityVisible(PlayerPedId(), (!MainMenu.PlayerOptionsMenu.PlayerInvisible && cf.IsAllowed(Permission.POInvisible)) || (!cf.IsAllowed(Permission.POInvisible)), false);
+                SetEntityVisible(PlayerPedId(), (!MainMenu.PlayerOptionsMenu.PlayerInvisible && cf.IsAllowed(Permission.POInvisible)) ||
+                    (!cf.IsAllowed(Permission.POInvisible)), false);
 
                 // Manage Stamina
                 if (MainMenu.PlayerOptionsMenu.PlayerStamina)
@@ -136,7 +137,8 @@ namespace vMenuClient
                 }
 
                 // Manage PlayerNoRagdoll
-                SetPedCanRagdoll(PlayerPedId(), (!MainMenu.PlayerOptionsMenu.PlayerNoRagdoll && cf.IsAllowed(Permission.PONoRagdoll)) || (!cf.IsAllowed(Permission.PONoRagdoll)));
+                SetPedCanRagdoll(PlayerPedId(), (!MainMenu.PlayerOptionsMenu.PlayerNoRagdoll && cf.IsAllowed(Permission.PONoRagdoll)) ||
+                    (!cf.IsAllowed(Permission.PONoRagdoll)));
 
 
                 // Fall off bike / dragged out of car.
@@ -231,7 +233,7 @@ namespace vMenuClient
                     // Freeze Vehicle Position (if enabled).
                     FreezeEntityPosition(vehicle.Handle, MainMenu.VehicleOptionsMenu.VehicleFrozen && cf.IsAllowed(Permission.VOFreeze));
 
-                    // If the torque multiplier is enabled.
+                    // If the torque multiplier is enabled and the player is allowed to use it.
                     if (MainMenu.VehicleOptionsMenu.VehicleTorqueMultiplier && cf.IsAllowed(Permission.VOTorqueMultiplier))
                     {
                         // Set the torque multiplier to the selected value by the player.
@@ -244,15 +246,19 @@ namespace vMenuClient
                         // Only needs to be set once.
                         SwitchedVehicle = false;
 
-                        // Vehicle engine power multiplier.
+                        // Vehicle engine power multiplier. Enable it once the player switched vehicles.
+                        // Only do this if the option is enabled AND the player has permissions for it.
                         if (MainMenu.VehicleOptionsMenu.VehiclePowerMultiplier && cf.IsAllowed(Permission.VOPowerMultiplier))
                         {
                             SetVehicleEnginePowerMultiplier(vehicle.Handle, MainMenu.VehicleOptionsMenu.VehiclePowerMultiplierAmount);
                         }
+                        // If the player switched vehicles and the option is turned off or the player has no permissions for it
+                        // Then reset the power multiplier ONCE.
                         else
                         {
                             SetVehicleEnginePowerMultiplier(vehicle.Handle, 1f);
                         }
+
                         // No Siren Toggle
                         vehicle.IsSirenSilent = MainMenu.VehicleOptionsMenu.VehicleNoSiren && cf.IsAllowed(Permission.VONoSiren);
                     }
@@ -297,8 +303,8 @@ namespace vMenuClient
                 }
 
                 // Manage vehicle engine always on.
-                if ((MainMenu.VehicleOptionsMenu.VehicleEngineAlwaysOn && DoesEntityExist(cf.GetVehicle(lastVehicle: true)) && !IsPedInAnyVehicle(PlayerPedId(), false)) &&
-                    (cf.IsAllowed(Permission.VOEngineAlwaysOn)))
+                if ((MainMenu.VehicleOptionsMenu.VehicleEngineAlwaysOn && DoesEntityExist(cf.GetVehicle(lastVehicle: true)) &&
+                    !IsPedInAnyVehicle(PlayerPedId(), false)) && (cf.IsAllowed(Permission.VOEngineAlwaysOn)))
                 {
                     await Delay(100);
                     SetVehicleEngineOn(cf.GetVehicle(lastVehicle: true), true, true, true);

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -639,6 +639,16 @@ namespace vMenuClient
 
                 // Enable/disable infinite ammo.
                 SetPedInfiniteAmmoClip(PlayerPedId(), MainMenu.WeaponOptionsMenu.UnlimitedAmmo && cf.IsAllowed(Permission.WPUnlimitedAmmo));
+
+                if (MainMenu.WeaponOptionsMenu.AutoEquipChute)
+                {
+                    if ((IsPedInAnyHeli(PlayerPedId()) || IsPedInAnyPlane(PlayerPedId())) && !HasPedGotWeapon(PlayerPedId(), (uint)WeaponHash.Parachute, false))
+                    {
+                        GiveWeaponToPed(PlayerPedId(), (uint)WeaponHash.Parachute, 1, false, true);
+                        SetPlayerHasReserveParachute(PlayerId());
+                        SetPlayerCanLeaveParachuteSmokeTrail(PlayerPedId(), true);
+                    }
+                }
             }
             else
             {

--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -23,7 +23,9 @@ namespace vMenuClient
         private bool firstTick = true;
         private static bool permissionsSetupDone = false;
         private static bool optionsSetupDone = false;
-        //public static Dictionary<string, bool> Permissions { get; private set; } = new Dictionary<string, bool>();
+        public static bool addonCarsLoaded = false;
+        public static bool addonPedsLoaded = false;
+        public static bool addonWeaponsLoaded = false;
 
         private static int MenuToggleKey = 244; // M by default (InteractionMenu)
         private static int NoClipKey = 289; // F2 by default (ReplayStartStopRecordingSecondary)
@@ -347,8 +349,10 @@ namespace vMenuClient
                 // Request the permissions data from the server.
                 TriggerServerEvent("vMenu:RequestPermissions", PlayerId());
 
-                // Wait until the data is received.
-                while (!permissionsSetupDone || !optionsSetupDone || GetPlayerName(PlayerId()) == "**Invalid**" || GetPlayerName(PlayerId()) == "** Invalid **")
+                // Wait until the data is received and the player's name is loaded correctly.
+                while (!permissionsSetupDone || !optionsSetupDone
+                    || GetPlayerName(PlayerId()) == "**Invalid**" || GetPlayerName(PlayerId()) == "** Invalid **" ||
+                    !addonCarsLoaded || !addonPedsLoaded || !addonWeaponsLoaded)
                 {
                     await Delay(0);
                 }

--- a/vMenu/PermissionsManager.cs
+++ b/vMenu/PermissionsManager.cs
@@ -70,6 +70,7 @@ namespace vMenuClient
         VSMenu,
         VSAll,
         VSSpawnByName,
+        VSAddon,
         VSCompacts,
         VSSedans,
         VSSUVs,

--- a/vMenu/PermissionsManager.cs
+++ b/vMenu/PermissionsManager.cs
@@ -128,6 +128,8 @@ namespace vMenuClient
         WPRemoveAll,
         WPUnlimitedAmmo,
         WPNoReload,
+        WPSpawn,
+        WPSetAllAmmo,
 
         // Misc Settings
         MSMenu,

--- a/vMenu/UserDefaults.cs
+++ b/vMenu/UserDefaults.cs
@@ -117,6 +117,12 @@ namespace vMenuClient
             get { return GetSettingsBool("weaponsUnlimitedAmmo"); }
             set { SetSavedSettingsBool("weaponsUnlimitedAmmo", value); }
         }
+
+        public static bool AutoEquipChute
+        {
+            get { return GetSettingsBool("autoEquipParachuteWhenInPlane"); }
+            set { SetSavedSettingsBool("autoEquipParachuteWhenInPlane", value); }
+        }
         #endregion
 
         #region Misc Settings
@@ -194,7 +200,7 @@ namespace vMenuClient
                 // Some options should be enabled by default:
                 if (kvpString == "unlimitedStamina" || kvpString == "miscDeathNotifications" || kvpString == "miscJoinQuitNotifications"
                     || kvpString == "vehicleSpawnerSpawnInside" || kvpString == "vehicleSpawnerReplacePrevious" || kvpString == "neverWanted"
-                    || kvpString == "voiceChatShowSpeaker" || kvpString == "voiceChatEnabled")
+                    || kvpString == "voiceChatShowSpeaker" || kvpString == "voiceChatEnabled" || kvpString == "autoEquipParachuteWhenInPlane")
                 {
                     SetSavedSettingsBool(kvpString, true);
                     return true;

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -75,12 +75,14 @@ namespace vMenuClient
             UIMenuItem deleteSavedPed = new UIMenuItem("Delete Saved Ped", "Delete one of your saved peds.");
             deleteSavedPed.SetRightLabel("→→→");
             deleteSavedPed.SetLeftBadge(UIMenuItem.BadgeStyle.Alert);
+            UIMenuItem spawnByName = new UIMenuItem("Spawn Ped By Name", "Enter a model name of a custom ped you want to spawn.");
 
             // Add items to the mneu.
             menu.AddItem(pedCustomization);
             menu.AddItem(savePed);
             menu.AddItem(spawnSavedPed);
             menu.AddItem(deleteSavedPed);
+            menu.AddItem(spawnByName);
 
             // Bind items to the submenus.
             if (cf.IsAllowed(Permission.PACustomize))
@@ -93,7 +95,6 @@ namespace vMenuClient
                 pedCustomization.SetLeftBadge(UIMenuItem.BadgeStyle.Lock);
                 pedCustomization.Description = "This option has been disabled by the server owner.";
             }
-
 
             if (cf.IsAllowed(Permission.PASpawnSaved))
             {
@@ -126,6 +127,10 @@ namespace vMenuClient
                 else if (item == savePed)
                 {
                     cf.SavePed();
+                }
+                else if (item == spawnByName)
+                {
+                    cf.SpawnPedByName();
                 }
             };
 

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -84,7 +84,6 @@ namespace vMenuClient
             menu.AddItem(savePed);
             menu.AddItem(spawnSavedPed);
             menu.AddItem(deleteSavedPed);
-            menu.AddItem(spawnByName);
 
             // Bind items to the submenus.
             if (cf.IsAllowed(Permission.PACustomize))

--- a/vMenu/menus/SavedVehicles.cs
+++ b/vMenu/menus/SavedVehicles.cs
@@ -105,6 +105,13 @@ namespace vMenuClient
                         UIMenuItem vehBtn = new UIMenuItem(savedVehicle.Key.Substring(4), "Click to spawn this saved vehicle.");
                         vehBtn.SetRightLabel($"({savedVehicle.Value["name"]})");
                         savedVehicles.AddItem(vehBtn);
+                        if (!IsModelInCdimage((uint)Int64.Parse(savedVehicle.Value["model"])))
+                        {
+                            vehBtn.SetLeftBadge(UIMenuItem.BadgeStyle.Lock);
+                            vehBtn.Enabled = false;
+                            vehBtn.Description = "This model is not available on this server, if this is an addon vehicle or DLC vehicle, please make sure " +
+                            "that it's being streamed on this server.";
+                        }
                     }
 
                     // Sort the menu items (case IN-sensitive) by name.

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -365,7 +365,7 @@ namespace vMenuClient
                         // Toggle engine
                         else if (item == toggleEngine)
                         {
-                            vehicle.IsEngineRunning = !vehicle.IsEngineRunning;
+                            SetVehicleEngineOn(vehicle.Handle, !vehicle.IsEngineRunning, false, true);
                         }
                         // Set license plate text
                         else if (item == setLicensePlateText)

--- a/vMenu/menus/WeaponOptions.cs
+++ b/vMenu/menus/WeaponOptions.cs
@@ -16,8 +16,11 @@ namespace vMenuClient
         private Notification Notify = MainMenu.Notify;
         private Subtitles Subtitle = MainMenu.Subtitle;
         private CommonFunctions cf = MainMenu.Cf;
-        public bool UnlimitedAmmo = UserDefaults.WeaponsUnlimitedAmmo;
-        public bool NoReload = UserDefaults.WeaponsNoReload;
+
+        public bool UnlimitedAmmo { get; private set; } = UserDefaults.WeaponsUnlimitedAmmo;
+        public bool NoReload { get; private set; } = UserDefaults.WeaponsNoReload;
+        public bool AutoEquipChute { get; private set; } = UserDefaults.AutoEquipChute;
+
         public static Dictionary<string, uint> AddonWeapons = new Dictionary<string, uint>();
 
         private Dictionary<UIMenu, ValidWeapon> weaponInfo = new Dictionary<UIMenu, ValidWeapon>();
@@ -126,20 +129,222 @@ namespace vMenuClient
                 addonWeaponsBtn.Description = "This option is not available on this server because you don't have permission to use it, or it is not setup correctly.";
             }
 
-            parachuteBtn.Enabled = false;
-            parachuteBtn.SetRightLabel("WIP");
-            parachuteBtn.SetLeftBadge(UIMenuItem.BadgeStyle.Lock);
-            menu.AddItem(parachuteBtn);
-            //menu.BindMenuToItem(parachuteMenu, parachuteBtn);
-
             addonWeaponsMenu.RefreshIndex();
             addonWeaponsMenu.UpdateScaleform();
+
+            UIMenu primaryChute = new UIMenu("Parachute Options", "Select A Primary Parachute", true)
+            {
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+                ControlDisablingEnabled = false,
+                ScaleWithSafezone = false
+            };
+
+            UIMenu secondaryChute = new UIMenu("Parachute Options", "Select A Reserve Parachute", true)
+            {
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+                ControlDisablingEnabled = false,
+                ScaleWithSafezone = false
+            };
+
+            UIMenuItem chute = new UIMenuItem("No Style", "Default parachute.");
+            UIMenuItem chute0 = new UIMenuItem(GetLabelText("PM_TINT0"), GetLabelText("PD_TINT0"));             // Rainbow Chute
+            UIMenuItem chute1 = new UIMenuItem(GetLabelText("PM_TINT1"), GetLabelText("PD_TINT1"));             // Red Chute
+            UIMenuItem chute2 = new UIMenuItem(GetLabelText("PM_TINT2"), GetLabelText("PD_TINT2"));             // Seaside Stripes Chute
+            UIMenuItem chute3 = new UIMenuItem(GetLabelText("PM_TINT3"), GetLabelText("PD_TINT3"));             // Window Maker Chute
+            UIMenuItem chute4 = new UIMenuItem(GetLabelText("PM_TINT4"), GetLabelText("PD_TINT4"));             // Patriot Chute
+            UIMenuItem chute5 = new UIMenuItem(GetLabelText("PM_TINT5"), GetLabelText("PD_TINT5"));             // Blue Chute
+            UIMenuItem chute6 = new UIMenuItem(GetLabelText("PM_TINT6"), GetLabelText("PD_TINT6"));             // Black Chute
+            UIMenuItem chute7 = new UIMenuItem(GetLabelText("PM_TINT7"), GetLabelText("PD_TINT7"));             // Hornet Chute
+            UIMenuItem chute8 = new UIMenuItem(GetLabelText("PS_CAN_0"), "Air Force parachute.");               // Air Force Chute
+            UIMenuItem chute9 = new UIMenuItem(GetLabelText("PM_TINT0"), "Desert parachute.");                  // Desert Chute
+            UIMenuItem chute10 = new UIMenuItem("Shadow Chute", "Shadow parachute.");                           // Shadow Chute
+            UIMenuItem chute11 = new UIMenuItem(GetLabelText("UNLOCK_NAME_PSRWD"), "High altitude parachute."); // High Altitude Chute
+            UIMenuItem chute12 = new UIMenuItem("Airborne Chute", "Airborne parachute.");                       // Airborne Chute
+            UIMenuItem chute13 = new UIMenuItem("Sunrise Chute", "Sunrise parachute.");                         // Sunrise Chute
+            UIMenuItem rchute = new UIMenuItem("No Style", "Default parachute.");
+            UIMenuItem rchute0 = new UIMenuItem(GetLabelText("PM_TINT0"), GetLabelText("PD_TINT0"));             // Rainbow Chute
+            UIMenuItem rchute1 = new UIMenuItem(GetLabelText("PM_TINT1"), GetLabelText("PD_TINT1"));             // Red Chute
+            UIMenuItem rchute2 = new UIMenuItem(GetLabelText("PM_TINT2"), GetLabelText("PD_TINT2"));             // Seaside Stripes Chute
+            UIMenuItem rchute3 = new UIMenuItem(GetLabelText("PM_TINT3"), GetLabelText("PD_TINT3"));             // Window Maker Chute
+            UIMenuItem rchute4 = new UIMenuItem(GetLabelText("PM_TINT4"), GetLabelText("PD_TINT4"));             // Patriot Chute
+            UIMenuItem rchute5 = new UIMenuItem(GetLabelText("PM_TINT5"), GetLabelText("PD_TINT5"));             // Blue Chute
+            UIMenuItem rchute6 = new UIMenuItem(GetLabelText("PM_TINT6"), GetLabelText("PD_TINT6"));             // Black Chute
+            UIMenuItem rchute7 = new UIMenuItem(GetLabelText("PM_TINT7"), GetLabelText("PD_TINT7"));             // Hornet Chute
+            UIMenuItem rchute8 = new UIMenuItem(GetLabelText("PS_CAN_0"), "Air Force parachute.");               // Air Force Chute
+            UIMenuItem rchute9 = new UIMenuItem(GetLabelText("PM_TINT0"), "Desert parachute.");                  // Desert Chute
+            UIMenuItem rchute10 = new UIMenuItem("Shadow Chute", "Shadow parachute.");                           // Shadow Chute
+            UIMenuItem rchute11 = new UIMenuItem(GetLabelText("UNLOCK_NAME_PSRWD"), "High altitude parachute."); // High Altitude Chute
+            UIMenuItem rchute12 = new UIMenuItem("Airborne Chute", "Airborne parachute.");                       // Airborne Chute
+            UIMenuItem rchute13 = new UIMenuItem("Sunrise Chute", "Sunrise parachute.");                         // Sunrise Chute
+
+            primaryChute.AddItem(chute);
+            primaryChute.AddItem(chute0);
+            primaryChute.AddItem(chute1);
+            primaryChute.AddItem(chute2);
+            primaryChute.AddItem(chute3);
+            primaryChute.AddItem(chute4);
+            primaryChute.AddItem(chute5);
+            primaryChute.AddItem(chute6);
+            primaryChute.AddItem(chute7);
+            primaryChute.AddItem(chute8);
+            primaryChute.AddItem(chute9);
+            primaryChute.AddItem(chute10);
+            primaryChute.AddItem(chute11);
+            primaryChute.AddItem(chute12);
+            primaryChute.AddItem(chute13);
+
+            secondaryChute.AddItem(rchute);
+            secondaryChute.AddItem(rchute0);
+            secondaryChute.AddItem(rchute1);
+            secondaryChute.AddItem(rchute2);
+            secondaryChute.AddItem(rchute3);
+            secondaryChute.AddItem(rchute4);
+            secondaryChute.AddItem(rchute5);
+            secondaryChute.AddItem(rchute6);
+            secondaryChute.AddItem(rchute7);
+            secondaryChute.AddItem(rchute8);
+            secondaryChute.AddItem(rchute9);
+            secondaryChute.AddItem(rchute10);
+            secondaryChute.AddItem(rchute11);
+            secondaryChute.AddItem(rchute12);
+            secondaryChute.AddItem(rchute13);
+
+            primaryChute.OnItemSelect += (sender, item, index) =>
+            {
+                SetPedParachuteTintIndex(PlayerPedId(), index - 1);
+                Subtitle.Custom($"Primary parachute style selected: ~r~{item.Text}~s~.");
+            };
+
+            secondaryChute.OnItemSelect += (sender, item, index) =>
+            {
+                SetPlayerReserveParachuteTintIndex(PlayerId(), index - 1);
+                Subtitle.Custom($"Reserve parachute style selected: ~r~{item.Text}~s~.");
+            };
+
+            UIMenuItem primaryChuteBtn = new UIMenuItem("Primary Parachute Style", "Select a primary parachute.");
+            UIMenuItem secondaryChuteBtn = new UIMenuItem("Reserve Parachute Style", "Select a reserve parachute.");
+
+            parachuteMenu.AddItem(primaryChuteBtn);
+            primaryChuteBtn.SetRightLabel("→→→");
+            parachuteMenu.AddItem(secondaryChuteBtn);
+            secondaryChuteBtn.SetRightLabel("→→→");
+
+            parachuteMenu.BindMenuToItem(primaryChute, primaryChuteBtn);
+            parachuteMenu.BindMenuToItem(secondaryChute, secondaryChuteBtn);
+
+            UIMenuCheckboxItem autoEquipParachute = new UIMenuCheckboxItem("Auto Equip Parachute", AutoEquipChute, "Automatically equip a parachute whenever you enter a plane/helicopter.");
+            parachuteMenu.AddItem(autoEquipParachute);
+
+            UIMenuItem togglePrimary = new UIMenuItem("Get / Remove Primary Parachute", "Equip a primary parachute.");
+            UIMenuItem toggleSecondary = new UIMenuItem("Get Reserve Parachute", "Equip a reserve parachute, you need to get a primary parachute first before equipping a reserve parachute.");
+
+            parachuteMenu.AddItem(togglePrimary);
+            parachuteMenu.AddItem(toggleSecondary);
+
+            parachuteMenu.OnItemSelect += (sender, item, index) =>
+            {
+                if (item == togglePrimary)
+                {
+                    if (HasPedGotWeapon(PlayerPedId(), (uint)WeaponHash.Parachute, false))
+                    {
+                        RemoveWeaponFromPed(PlayerPedId(), (uint)WeaponHash.Parachute);
+                        Notify.Success("Primary parachute ~r~removed~s~.", true);
+                    }
+                    else
+                    {
+                        GiveWeaponToPed(PlayerPedId(), (uint)WeaponHash.Parachute, 1, false, false);
+                        Notify.Success("Primary parachute ~g~equippped~s~.", true);
+                    }
+                }
+                else if (item == toggleSecondary)
+                {
+                    if (GetPlayerHasReserveParachute(PlayerId()))
+                    {
+                        RemoveWeaponFromPed(PlayerPedId(), (uint)WeaponHash.Parachute);
+                        GiveWeaponToPed(PlayerPedId(), (uint)WeaponHash.Parachute, 1, false, true);
+                        Notify.Success("Reserve parachute ~r~removed~s~.", true);
+                    }
+                    else
+                    {
+                        SetPlayerHasReserveParachute(PlayerId());
+                        Notify.Success("Reserve parachute ~g~equippped~s~.", true);
+                    }
+                }
+            };
+
+            parachuteMenu.OnCheckboxChange += (sender, item, _checked) =>
+            {
+                if (item == autoEquipParachute)
+                {
+                    AutoEquipChute = _checked;
+                }
+            };
+            List<dynamic> smokeColor = new List<dynamic>()
+            {
+                "White",
+                "Yellow",
+                "Red",
+                "Green",
+                "Blue",
+                "Dark Gray",
+            };
+
+
+            UIMenuListItem smokeColors = new UIMenuListItem("Smoke Trail Color", smokeColor, 0, "Select a parachute smoke trail color.");
+            parachuteMenu.AddItem(smokeColors);
+            parachuteMenu.OnListChange += (sender, item, index) =>
+            {
+                if (item == smokeColors)
+                {
+                    SetPlayerCanLeaveParachuteSmokeTrail(PlayerId(), false);
+                    if (index == 0)
+                    {
+                        SetPlayerParachuteSmokeTrailColor(PlayerId(), 255, 255, 255);
+                    }
+                    else if (index == 1)
+                    {
+                        SetPlayerParachuteSmokeTrailColor(PlayerId(), 255, 255, 0);
+                    }
+                    else if (index == 2)
+                    {
+                        SetPlayerParachuteSmokeTrailColor(PlayerId(), 255, 0, 0);
+                    }
+                    else if (index == 3)
+                    {
+                        SetPlayerParachuteSmokeTrailColor(PlayerId(), 0, 255, 0);
+                    }
+                    else if (index == 4)
+                    {
+                        SetPlayerParachuteSmokeTrailColor(PlayerId(), 0, 0, 255);
+                    }
+                    else if (index == 5)
+                    {
+                        SetPlayerParachuteSmokeTrailColor(PlayerId(), 1, 1, 1);
+                    }
+
+                    SetPlayerCanLeaveParachuteSmokeTrail(PlayerId(), true);
+                }
+            };
+
+            menu.AddItem(parachuteBtn);
+            parachuteBtn.SetRightLabel("→→→");
+            menu.BindMenuToItem(parachuteMenu, parachuteBtn);
 
             parachuteMenu.RefreshIndex();
             parachuteMenu.UpdateScaleform();
 
+            primaryChute.RefreshIndex();
+            primaryChute.UpdateScaleform();
+
+            secondaryChute.RefreshIndex();
+            secondaryChute.UpdateScaleform();
+
             MainMenu.Mp.Add(addonWeaponsMenu);
             MainMenu.Mp.Add(parachuteMenu);
+            MainMenu.Mp.Add(primaryChute);
+            MainMenu.Mp.Add(secondaryChute);
 
             foreach (ValidWeapon weapon in vw.WeaponList)
             {

--- a/vMenu/menus/WeaponOptions.cs
+++ b/vMenu/menus/WeaponOptions.cs
@@ -260,17 +260,8 @@ namespace vMenuClient
                 }
                 else if (item == toggleSecondary)
                 {
-                    if (GetPlayerHasReserveParachute(PlayerId()))
-                    {
-                        RemoveWeaponFromPed(PlayerPedId(), (uint)WeaponHash.Parachute);
-                        GiveWeaponToPed(PlayerPedId(), (uint)WeaponHash.Parachute, 1, false, true);
-                        Notify.Success("Reserve parachute ~r~removed~s~.", true);
-                    }
-                    else
-                    {
-                        SetPlayerHasReserveParachute(PlayerId());
-                        Notify.Success("Reserve parachute ~g~equippped~s~.", true);
-                    }
+                    SetPlayerHasReserveParachute(PlayerId());
+                    Notify.Success("Reserve parachute ~g~equippped~s~.", true);
                 }
             };
 
@@ -281,6 +272,7 @@ namespace vMenuClient
                     AutoEquipChute = _checked;
                 }
             };
+
             List<dynamic> smokeColor = new List<dynamic>()
             {
                 "White",
@@ -290,7 +282,6 @@ namespace vMenuClient
                 "Blue",
                 "Dark Gray",
             };
-
 
             UIMenuListItem smokeColors = new UIMenuListItem("Smoke Trail Color", smokeColor, 0, "Select a parachute smoke trail color.");
             parachuteMenu.AddItem(smokeColors);

--- a/vMenuServer/EventManager.cs
+++ b/vMenuServer/EventManager.cs
@@ -187,6 +187,8 @@ namespace vMenuServer
             "VCStaffChannel",
         };
         public List<string> addonVehicles = new List<string>();
+        public List<string> addonPeds = new List<string>();
+        public List<string> addonWeapons = new List<string>();
 
         #region Constructor
         /// <summary>
@@ -226,6 +228,24 @@ namespace vMenuServer
                     {
                         if (debug) { Debug.WriteLine("Addon vehicle loaded: " + modelName, ""); }
                         addonVehicles.Add(modelName);
+                    }
+                }
+
+                if (json.ContainsKey("peds"))
+                {
+                    foreach (var modelName in json["peds"])
+                    {
+                        if (debug) { Debug.WriteLine("Addon ped loaded:" + modelName, ""); }
+                        addonPeds.Add(modelName);
+                    }
+                }
+
+                if (json.ContainsKey("weapons"))
+                {
+                    foreach (var modelName in json["weapons"])
+                    {
+                        if (debug) { Debug.WriteLine("Addon weapon loaded:" + modelName, ""); }
+                        addonWeapons.Add(modelName);
                     }
                 }
 
@@ -444,6 +464,8 @@ namespace vMenuServer
         {
             // First send the vehicle & ped addons list
             TriggerClientEvent(player, "vMenu:SetupAddonCars", "vehicles", addonVehicles);
+            TriggerClientEvent(player, "vMenu:SetupAddonPeds", "peds", addonPeds);
+            TriggerClientEvent(player, "vMenu:SetupAddonWeapons", "weapons", addonWeapons);
 
             // Get Permissions
             Dictionary<string, bool> perms = new Dictionary<string, bool>();

--- a/vMenuServer/config/addons.json
+++ b/vMenuServer/config/addons.json
@@ -1,0 +1,15 @@
+{
+  "vehicles": [
+    "mgt",
+    "addonvehiclename1",
+    "addonvehiclename2"
+  ],
+  "peds": [
+    "addonpedname1",
+    "addonpedname2"
+  ],
+  "weapons": [
+    "addonweaponname1",
+    "addonweaponname2"
+  ]
+}

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -147,6 +147,8 @@ add_ace builtin.everyone "vMenu.WeaponOptions.All" allow
 #add_ace builtin.everyone "vMenu.WeaponOptions.RemoveAll" allow
 #add_ace builtin.everyone "vMenu.WeaponOptions.UnlimitedAmmo" allow
 #add_ace builtin.everyone "vMenu.WeaponOptions.NoReload" allow
+#add_ace builtin.everyone "vMenu.WeaponOptions.Spawn" allow
+#add_ace builtin.everyone "vMenu.WeaponOptions.SetAllAmmo" allow
 
 # Misc Settings
 add_ace builtin.everyone "vMenu.MiscSettings.Menu" allow

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -89,6 +89,7 @@ add_ace builtin.everyone "vMenu.VehicleOptions.All" allow
 add_ace builtin.everyone "vMenu.VehicleSpawner.Menu" allow
 add_ace builtin.everyone "vMenu.VehicleSpawner.All" allow
 #add_ace builtin.everyone "vMenu.VehicleSpawner.SpawnByName" allow
+#add_ace builtin.everyone "vMenu.VehicleSpawner.Addon" allow # allows you to spawn an addon car from the Addon Vehicles list.
 #add_ace builtin.everyone "vMenu.VehicleSpawner.Compacts" allow
 #add_ace builtin.everyone "vMenu.VehicleSpawner.Sedans" allow
 #add_ace builtin.everyone "vMenu.VehicleSpawner.SUVs" allow

--- a/vMenuServer/vMenuServer.csproj
+++ b/vMenuServer/vMenuServer.csproj
@@ -56,6 +56,9 @@
     <Compile Include="UpdateChecker.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="config\addons.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="config\permissions.cfg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CustomToolNamespace>config</CustomToolNamespace>


### PR DESCRIPTION
## New features, bug-fixes and removed/improved some things.
### Changed things
- Temporary workaround for engine on/off toggle bug.
- Cleaned up code.

### Removed things
- Disabled saved car spawning if the car is not available on the current server (addon/future dlc cars for example).

### Added things
+ Added addon vehicles, peds and weapons lists, which can be customized by the server owner (checkout the new addons.json file). Players need permission to spawn vehicles/peds/weapons to be able to spawn each one from the addons list.
+ Added "Spawn Weapon By Name" option.
+ Added "Spawn Player Model By Name" option.
+ Added "Set All Ammo" and "Refill All Ammo" buttons to set/refill the ammo in _all_ of your weapons at once. Requires the `vMenu.WeaponOptions.SetAllAmmo` permission (that single permission will grant access to both those options).
+ Added parachute options menu to the "Weapon Options" menu. Equip primary and reserve parachutes, change the style of each of them and set a smoke trail color.
+ Added permission support for spawning weapons: `vMenu.WeaponOptions.Spawn` is now required to be able to spawn any weapon. (Note, if you have the `vMenu.WeaponOptions.GetAll` permission, you'll still be able to use the "Get All Weapons" button even if you don't have the `vMenu.WeaponOptions.Spawn` permission.
+ Added driving tasks options. (Player Options > Player Actions > Drive To Waypoint / Drive Around Randomly). Note that it's still a WIP and you can't set a custom driving style just yet. It's currently set to "rushed".

### Fixed
- Fixed a small issue regarding the window title when getting user input (the black input box).