### PR TITLE
v1.1.0 - New features, changes and some bug fixes.

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -167,6 +167,7 @@
 |:-|:-|:-|
 |`vMenu.MiscSettings.Menu`|Grants access to the Misc Settings Menu.|Allowed|
 |`vMenu.MiscSettings.All`|Grants access to **ALL** `Misc Settings Menu` options.|Denied|
+|`vMenu.MiscSettings.ClearArea`|Allows you to reset/clear everything 100m around you in the world.|Allowed|
 |`vMenu.MiscSettings.TeleportToWp`|Allows you to teleport to the waypoint on your map.|Allowed|
 |`vMenu.MiscSettings.ShowCoordinates`|Allows you to show your current coordinates on screen.|Allowed|
 |`vMenu.MiscSettings.ShowLocation`|Allows you to show your current location on screen (pretty much just like PLD).|Allowed|

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -561,16 +561,7 @@ namespace vMenuClient
                 {
                     // Convert it into a model hash.
                     uint model = (uint)GetHashKey(result);
-                    int modelClass = GetVehicleClassFromName(model);
-                    //var tmpMenu = new VehicleSpawner()
-                    if (MainMenu.VehicleSpawnerMenu.allowedCategories[modelClass])
-                    {
-                        SpawnVehicle(vehicleHash: model, spawnInside: spawnInside, replacePrevious: replacePrevious, skipLoad: false);
-                    }
-                    else
-                    {
-                        Notify.Alert("You are not allowed to spawn this vehicle, because it belongs to a category which is restricted by the server owner.");
-                    }
+                    SpawnVehicle(vehicleHash: model, spawnInside: spawnInside, replacePrevious: replacePrevious, skipLoad: false);
                 }
                 // Result was invalid.
                 else
@@ -594,6 +585,14 @@ namespace vMenuClient
         /// <param name="skipLoad">If true, this will not load or verify the model, it will instantly spawn the vehicle.</param>
         public async void SpawnVehicle(uint vehicleHash, bool spawnInside, bool replacePrevious, bool skipLoad = false, Dictionary<string, string> vehicleInfo = null, string saveName = null)
         {
+            var vehClass = GetVehicleClassFromName(vehicleHash);
+            int modelClass = GetVehicleClassFromName(vehicleHash);
+            if (!MainMenu.VehicleSpawnerMenu.allowedCategories[modelClass])
+            {
+                Notify.Alert("You are not allowed to spawn this vehicle, because it belongs to a category which is restricted by the server owner.");
+                return;
+            }
+
             if (!skipLoad)
             {
                 bool successFull = await LoadModel(vehicleHash);

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1823,9 +1823,9 @@ namespace vMenuClient
         {
             string output = "~h~";
             int length = title.Length;
-            int totalSize = 90 - int.Parse((length * 3).ToString());
+            int totalSize = 80 - length;
 
-            for (var i = 0; i < totalSize / 2; i++)
+            for (var i = 0; i < totalSize / 2 - (length / 2); i++)
             {
                 output += " ";
             }

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -192,13 +192,15 @@ namespace vMenuClient
                     if (!MainMenu.NoClipEnabled)
                     {
                         // Manage player frozen.
-                        FreezeEntityPosition(PlayerPedId(), MainMenu.PlayerOptionsMenu.PlayerFrozen && cf.IsAllowed(Permission.POFreeze));
+                        if (MainMenu.PlayerOptionsMenu.PlayerFrozen && cf.IsAllowed(Permission.POFreeze))
+                            FreezeEntityPosition(PlayerPedId(), true);
                     }
                 }
                 else
                 {
                     // Manage player frozen.
-                    FreezeEntityPosition(PlayerPedId(), MainMenu.PlayerOptionsMenu.PlayerFrozen && cf.IsAllowed(Permission.POFreeze));
+                    if (MainMenu.PlayerOptionsMenu.PlayerFrozen && cf.IsAllowed(Permission.POFreeze))
+                        FreezeEntityPosition(PlayerPedId(), true);
                 }
 
 
@@ -251,7 +253,11 @@ namespace vMenuClient
                     }
 
                     // Freeze Vehicle Position (if enabled).
-                    FreezeEntityPosition(vehicle.Handle, MainMenu.VehicleOptionsMenu.VehicleFrozen && cf.IsAllowed(Permission.VOFreeze));
+                    if (MainMenu.VehicleOptionsMenu.VehicleFrozen && cf.IsAllowed(Permission.VOFreeze))
+                    {
+                        FreezeEntityPosition(vehicle.Handle, true);
+                    }
+
 
                     // If the torque multiplier is enabled and the player is allowed to use it.
                     if (MainMenu.VehicleOptionsMenu.VehicleTorqueMultiplier && cf.IsAllowed(Permission.VOTorqueMultiplier))

--- a/vMenu/PermissionsManager.cs
+++ b/vMenu/PermissionsManager.cs
@@ -135,6 +135,7 @@ namespace vMenuClient
         // Misc Settings
         MSMenu,
         MSAll,
+        MSClearArea,
         MSTeleportToWp,
         MSShowCoordinates,
         MSShowLocation,
@@ -142,6 +143,8 @@ namespace vMenuClient
         MSDeathNotifs,
         MSNightVision,
         MSThermalVision,
+        
+
 
         // Voice Chat
         VCMenu,

--- a/vMenu/Vehicles.cs
+++ b/vMenu/Vehicles.cs
@@ -385,6 +385,7 @@ namespace vMenuClient
             "INSURGENT2",
             "INSURGENT3",
             "KALAHARI",
+            "KAMACHO",
             "MARSHALL",
             "MESA3",
             "MONSTER",

--- a/vMenu/menus/MiscSettings.cs
+++ b/vMenu/menus/MiscSettings.cs
@@ -57,6 +57,9 @@ namespace vMenuClient
             UIMenuCheckboxItem deathNotifs = new UIMenuCheckboxItem("Death Notifications", DeathNotifications, "Receive notifications when someone dies or gets killed.");
             UIMenuCheckboxItem nightVision = new UIMenuCheckboxItem("Toggle Night Vision", NightVision, "Enable or disable night vision.");
             UIMenuCheckboxItem thermalVision = new UIMenuCheckboxItem("Toggle Thermal Vision", ThermalVision, "Enable or disable thermal vision.");
+
+            UIMenuItem clearArea = new UIMenuItem("Clear Area", "Clears the area around your player (100 meters) of everything! Damage, dirt, peds, props, vehicles, etc. Everything gets cleaned up and reset.");
+
             // Add menu items to the menu.
             if (cf.IsAllowed(Permission.MSTeleportToWp))
             {
@@ -90,6 +93,10 @@ namespace vMenuClient
             if (cf.IsAllowed(Permission.MSThermalVision))
             {
                 menu.AddItem(thermalVision);
+            }
+            if (cf.IsAllowed(Permission.MSClearArea))
+            {
+                menu.AddItem(clearArea);
             }
 
             // Always allowed
@@ -153,6 +160,11 @@ namespace vMenuClient
                 else if (item == saveSettings)
                 {
                     UserDefaults.SaveSettingsAsync();
+                }
+                else if (item == clearArea)
+                {
+                    var pos = Game.PlayerPed.Position;
+                    ClearAreaOfEverything(pos.X, pos.Y, pos.Z, 100f, false, false, false, false);
                 }
             };
         }

--- a/vMenu/menus/PlayerOptions.cs
+++ b/vMenu/menus/PlayerOptions.cs
@@ -181,6 +181,8 @@ namespace vMenuClient
                 else if (item == playerFrozenCheckbox)
                 {
                     PlayerFrozen = _checked;
+                    if (!_checked)
+                        FreezeEntityPosition(PlayerPedId(), false);
                 }
             };
 

--- a/vMenu/menus/SavedVehicles.cs
+++ b/vMenu/menus/SavedVehicles.cs
@@ -35,7 +35,7 @@ namespace vMenuClient
                 ControlDisablingEnabled = false
             };
             // Create submenus.
-            UIMenu savedVehicles = new UIMenu(menuTitle, "Spawn Saved Vehicle", true)
+            UIMenu spawnSavedVehicles = new UIMenu(menuTitle, "Spawn Saved Vehicle", true)
             {
                 ScaleWithSafezone = false,
                 MouseControlsEnabled = false,
@@ -69,7 +69,7 @@ namespace vMenuClient
             // Bind submenus to menu items.
             if (cf.IsAllowed(Permission.SVSpawn))
             {
-                menu.BindMenuToItem(savedVehicles, savedVehiclesBtn);
+                menu.BindMenuToItem(spawnSavedVehicles, savedVehiclesBtn);
             }
             else
             {
@@ -94,7 +94,7 @@ namespace vMenuClient
                 else if (item == savedVehiclesBtn)
                 {
                     // Remove all old items.
-                    savedVehicles.MenuItems.Clear();
+                    spawnSavedVehicles.MenuItems.Clear();
 
                     // Get all saved vehicles.
                     SavedVehiclesDict = cf.GetSavedVehiclesDictionary();
@@ -105,7 +105,7 @@ namespace vMenuClient
                         //MainMenu.Cf.Log(savedVehicle.ToString());
                         UIMenuItem vehBtn = new UIMenuItem(savedVehicle.Key.Substring(4), "Click to spawn this saved vehicle.");
                         vehBtn.SetRightLabel($"({savedVehicle.Value["name"]})");
-                        savedVehicles.AddItem(vehBtn);
+                        spawnSavedVehicles.AddItem(vehBtn);
                         if (!IsModelInCdimage((uint)Int64.Parse(savedVehicle.Value["model"])))
                         {
                             vehBtn.SetLeftBadge(UIMenuItem.BadgeStyle.Lock);
@@ -116,24 +116,12 @@ namespace vMenuClient
                     }
 
                     // Sort the menu items (case IN-sensitive) by name.
-                    savedVehicles.MenuItems.Sort((pair1, pair2) => pair1.Text.ToString().ToLower().CompareTo(pair2.Text.ToString().ToLower()));
-
-                    // When a vehicle is selected...
-                    savedVehicles.OnItemSelect += (sender2, item2, index2) =>
-                    {
-                        Dictionary<string, string> vehInfo = SavedVehiclesDict["veh_" + item2.Text];
-
-                        // Get the model hash.
-                        var model = vehInfo["model"];
-
-                        // Spawn a vehicle using the hash, and pass on the vehicleInfo dictionary containing all saved vehicle mods.
-                        cf.SpawnVehicle((uint)Int64.Parse(model), MainMenu.VehicleSpawnerMenu.SpawnInVehicle, MainMenu.VehicleSpawnerMenu.ReplaceVehicle, vehicleInfo: vehInfo, saveName: item2.Text);
-                    };
+                    spawnSavedVehicles.MenuItems.Sort((pair1, pair2) => pair1.Text.ToString().ToLower().CompareTo(pair2.Text.ToString().ToLower()));
 
                     // Refresh the index of the page.
-                    savedVehicles.RefreshIndex();
+                    spawnSavedVehicles.RefreshIndex();
                     // Update the scaleform.
-                    savedVehicles.UpdateScaleform();
+                    spawnSavedVehicles.UpdateScaleform();
                 }
                 // Delete saved vehicle.
                 else if (item == deleteSavedVehiclesBtn)
@@ -155,20 +143,36 @@ namespace vMenuClient
 
                     // Sort the menu items (case IN-sensitive) by name.
                     deleteSavedVehicles.MenuItems.Sort((pair1, pair2) => pair1.Text.ToString().ToLower().CompareTo(pair2.Text.ToString().ToLower()));
-
-                    // Handle vehicle deletions
-                    deleteSavedVehicles.OnItemSelect += (sender2, item2, index2) =>
-                    {
-                        var vehDictName = "veh_" + item2.Text;
-                        new StorageManager().DeleteSavedDictionary(vehDictName);
-                        deleteSavedVehicles.GoBack();
-                    };
+                    deleteSavedVehicles.RefreshIndex();
+                    deleteSavedVehicles.UpdateScaleform();
                 }
             };
             #endregion
 
+            #region Handle saved vehicles being pressed. (spawning)
+            // When a vehicle is selected...
+            spawnSavedVehicles.OnItemSelect += (sender2, item2, index2) =>
+            {
+                Dictionary<string, string> vehInfo = SavedVehiclesDict["veh_" + item2.Text];
+
+                // Get the model hash.
+                var model = vehInfo["model"];
+
+                // Spawn a vehicle using the hash, and pass on the vehicleInfo dictionary containing all saved vehicle mods.
+                cf.SpawnVehicle((uint)Int64.Parse(model), MainMenu.VehicleSpawnerMenu.SpawnInVehicle, MainMenu.VehicleSpawnerMenu.ReplaceVehicle, vehicleInfo: vehInfo, saveName: item2.Text);
+            };
+
+            // Handle vehicle deletions
+            deleteSavedVehicles.OnItemSelect += (sender2, item2, index2) =>
+            {
+                var vehDictName = "veh_" + item2.Text;
+                new StorageManager().DeleteSavedDictionary(vehDictName);
+                deleteSavedVehicles.GoBack();
+            };
+            #endregion
+
             // Add the submenus to the menu pool.
-            MainMenu.Mp.Add(savedVehicles);
+            MainMenu.Mp.Add(spawnSavedVehicles);
             MainMenu.Mp.Add(deleteSavedVehicles);
         }
 

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -402,6 +402,8 @@ namespace vMenuClient
                 else if (item == vehicleFreeze) // Freeze Vehicle Toggled
                 {
                     VehicleFrozen = _checked;
+                    if (!_checked)
+                        FreezeEntityPosition(cf.GetVehicle(), false);
                 }
                 else if (item == torqueEnabled) // Enable Torque Multiplier Toggled
                 {

--- a/vMenu/menus/WeaponOptions.cs
+++ b/vMenu/menus/WeaponOptions.cs
@@ -363,9 +363,136 @@ namespace vMenuClient
             #endregion
             #endregion
 
+            UIMenuItem spacer = cf.GetSpacerMenuItem("↓ Weapon Categories ↓");
+            menu.AddItem(spacer);
+
+            UIMenu handGuns = new UIMenu("Weapons", "Handguns", true)
+            {
+                ScaleWithSafezone = false,
+                ControlDisablingEnabled = false,
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+            };
+            handGuns.SetMenuWidthOffset(50);
+            UIMenuItem handGunsBtn = new UIMenuItem("Handguns");
+
+            UIMenu rifles = new UIMenu("Weapons", "Assault Rifles", true)
+            {
+                ScaleWithSafezone = false,
+                ControlDisablingEnabled = false,
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+            };
+            rifles.SetMenuWidthOffset(50);
+            UIMenuItem riflesBtn = new UIMenuItem("Assault Rifles");
+
+            UIMenu shotguns = new UIMenu("Weapons", "Shotguns", true)
+            {
+                ScaleWithSafezone = false,
+                ControlDisablingEnabled = false,
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+            };
+            shotguns.SetMenuWidthOffset(50);
+            UIMenuItem shotgunsBtn = new UIMenuItem("Shotguns");
+
+            UIMenu smgs = new UIMenu("Weapons", "Sub-/Light Machine Guns", true)
+            {
+                ScaleWithSafezone = false,
+                ControlDisablingEnabled = false,
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+            };
+            smgs.SetMenuWidthOffset(50);
+            UIMenuItem smgsBtn = new UIMenuItem("Sub-/Light Machine Guns");
+
+            UIMenu throwables = new UIMenu("Weapons", "Throwables", true)
+            {
+                ScaleWithSafezone = false,
+                ControlDisablingEnabled = false,
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+            };
+            throwables.SetMenuWidthOffset(50);
+            UIMenuItem throwablesBtn = new UIMenuItem("Throwables");
+
+            UIMenu melee = new UIMenu("Weapons", "Melee", true)
+            {
+                ScaleWithSafezone = false,
+                ControlDisablingEnabled = false,
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+            };
+            melee.SetMenuWidthOffset(50);
+            UIMenuItem meleeBtn = new UIMenuItem("Melee");
+
+            UIMenu heavy = new UIMenu("Weapons", "Heavy Weapons", true)
+            {
+                ScaleWithSafezone = false,
+                ControlDisablingEnabled = false,
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+            };
+            heavy.SetMenuWidthOffset(50);
+            UIMenuItem heavyBtn = new UIMenuItem("Heavy Weapons");
+
+            UIMenu snipers = new UIMenu("Weapons", "Sniper Rifles", true)
+            {
+                ScaleWithSafezone = false,
+                ControlDisablingEnabled = false,
+                MouseControlsEnabled = false,
+                MouseEdgeEnabled = false,
+            };
+            snipers.SetMenuWidthOffset(50);
+            UIMenuItem snipersBtn = new UIMenuItem("Sniper Rifles");
+
+
+            MainMenu.Mp.Add(handGuns);
+            MainMenu.Mp.Add(rifles);
+            MainMenu.Mp.Add(shotguns);
+            MainMenu.Mp.Add(smgs);
+            MainMenu.Mp.Add(throwables);
+            MainMenu.Mp.Add(melee);
+            MainMenu.Mp.Add(heavy);
+            MainMenu.Mp.Add(snipers);
+
+            handGunsBtn.SetRightLabel("→→→");
+            menu.AddItem(handGunsBtn);
+            menu.BindMenuToItem(handGuns, handGunsBtn);
+
+            riflesBtn.SetRightLabel("→→→");
+            menu.AddItem(riflesBtn);
+            menu.BindMenuToItem(rifles, riflesBtn);
+
+            shotgunsBtn.SetRightLabel("→→→");
+            menu.AddItem(shotgunsBtn);
+            menu.BindMenuToItem(shotguns, shotgunsBtn);
+
+            smgsBtn.SetRightLabel("→→→");
+            menu.AddItem(smgsBtn);
+            menu.BindMenuToItem(smgs, smgsBtn);
+
+            throwablesBtn.SetRightLabel("→→→");
+            menu.AddItem(throwablesBtn);
+            menu.BindMenuToItem(throwables, throwablesBtn);
+
+            meleeBtn.SetRightLabel("→→→");
+            menu.AddItem(meleeBtn);
+            menu.BindMenuToItem(melee, meleeBtn);
+
+            heavyBtn.SetRightLabel("→→→");
+            menu.AddItem(heavyBtn);
+            menu.BindMenuToItem(heavy, heavyBtn);
+
+            snipersBtn.SetRightLabel("→→→");
+            menu.AddItem(snipersBtn);
+            menu.BindMenuToItem(snipers, snipersBtn);
+
+
             #region Loop through all weapons, create menus for them and add all menu items and handle events.
             foreach (ValidWeapon weapon in vw.WeaponList)
             {
+                uint cat = (uint)GetWeapontypeGroup(weapon.Hash);
                 if (weapon.Name != null)
                 {
                     #region Create menu for this weapon and add buttons
@@ -518,8 +645,49 @@ namespace vMenuClient
                     weaponMenu.RefreshIndex();
                     weaponMenu.UpdateScaleform();
 
-                    menu.AddItem(weaponItem);
-                    menu.BindMenuToItem(weaponMenu, weaponItem);
+                    if (cat == 970310034) // 970310034 rifles
+                    {
+                        rifles.AddItem(weaponItem);
+                        rifles.BindMenuToItem(weaponMenu, weaponItem);
+                    }
+                    else if (cat == 416676503 || cat == 690389602) // 416676503 hand guns // 690389602 stun gun
+                    {
+                        handGuns.AddItem(weaponItem);
+                        handGuns.BindMenuToItem(weaponMenu, weaponItem);
+                    }
+                    else if (cat == 860033945) // 860033945 shotguns
+                    {
+                        shotguns.AddItem(weaponItem);
+                        shotguns.BindMenuToItem(weaponMenu, weaponItem);
+                    }
+                    else if (cat == 3337201093 || cat == 1159398588) // 3337201093 sub machine guns // 1159398588 light machine guns
+                    {
+                        smgs.AddItem(weaponItem);
+                        smgs.BindMenuToItem(weaponMenu, weaponItem);
+                    }
+                    else if (cat == 1548507267 || cat == 4257178988 || cat == 1595662460) // 1548507267 throwables // 4257178988 fire extinghuiser // jerry can
+                    {
+                        throwables.AddItem(weaponItem);
+                        throwables.BindMenuToItem(weaponMenu, weaponItem);
+                    }
+                    else if (cat == 3566412244 || cat == 2685387236) // 3566412244 melee weapons // 2685387236 knuckle duster
+                    {
+                        melee.AddItem(weaponItem);
+                        melee.BindMenuToItem(weaponMenu, weaponItem);
+                    }
+                    else if (cat == 2725924767) // 2725924767 heavy weapons
+                    {
+                        heavy.AddItem(weaponItem);
+                        heavy.BindMenuToItem(weaponMenu, weaponItem);
+                    }
+                    else if (cat == 3082541095) // 3082541095 sniper rifles
+                    {
+                        snipers.AddItem(weaponItem);
+                        snipers.BindMenuToItem(weaponMenu, weaponItem);
+                    }
+
+
+
                 }
             }
             #endregion

--- a/vMenu/vMenuClient.csproj
+++ b/vMenu/vMenuClient.csproj
@@ -41,6 +41,7 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/vMenuServer/EventManager.cs
+++ b/vMenuServer/EventManager.cs
@@ -426,18 +426,23 @@ namespace vMenuServer
         /// <param name="kickReason"></param>
         private void KickPlayer([FromSource] Player source, int target, string kickReason = "You have been kicked from the server.")
         {
-            // If the player is allowed to be kicked.
-            var targetPlayer = new PlayerList()[target];
-            if (!IsPlayerAceAllowed(targetPlayer.Handle, "vMenu.DontKickMe"))
+            if (IsPlayerAceAllowed(source.ToString(), "vMenu.OnlinePlayers.Kick"))
             {
-                // Kick the player from the server using the specified reason.
-                DropPlayer(targetPlayer.Handle, kickReason);
-            }
-            else
-            {
+                // If the player is allowed to be kicked.
+                var targetPlayer = new PlayerList()[target];
+                if (!IsPlayerAceAllowed(targetPlayer.Handle, "vMenu.DontKickMe"))
+                {
+                    // Kick the player from the server using the specified reason.
+                    DropPlayer(targetPlayer.Handle, kickReason);
+                    return;
+                }
                 // Trigger the client event on the source player to let them know that kicking this player is not allowed.
                 TriggerClientEvent(player: source, eventName: "vMenu:KickCallback", args: "Sorry, this player can ~r~not ~w~be kicked.");
+                return;
             }
+            // If this happens, the person who thinks they're funny knows exactly what this is for.
+            TriggerClientEvent(player: source, eventName: "vMenu:KickCallback", args: "Have a nice day :)");
+            // todo: Make sure they enjoy their day.
         }
 
         /// <summary>
@@ -447,9 +452,14 @@ namespace vMenuServer
         /// <param name="target"></param>
         private void KillPlayer([FromSource] Player source, int target)
         {
-            var targetPlayer = new PlayerList()[target];
-            // Trigger the client event on the target player to make them kill themselves. R.I.P.
-            TriggerClientEvent(player: targetPlayer, eventName: "vMenu:KillMe");
+            if (IsPlayerAceAllowed(source.ToString(), "vMenu.OnlinePlayers.Kill"))
+            {
+                var targetPlayer = new PlayerList()[target];
+                // Trigger the client event on the target player to make them kill themselves. R.I.P.
+                TriggerClientEvent(player: targetPlayer, eventName: "vMenu:KillMe");
+                return;
+            }
+            // todo: enjoy.
         }
 
         /// <summary>
@@ -459,9 +469,14 @@ namespace vMenuServer
         /// <param name="target"></param>
         private void SummonPlayer([FromSource] Player source, int target)
         {
-            // Trigger the client event on the target player to make them teleport to the source player.
-            var targetPlayer = new PlayerList()[target];
-            TriggerClientEvent(player: targetPlayer, eventName: "vMenu:GoToPlayer", args: source.Handle);
+            if (IsPlayerAceAllowed(source.ToString(), "vMenu.OnlinePlayers.Summon"))
+            {
+                // Trigger the client event on the target player to make them teleport to the source player.
+                var targetPlayer = new PlayerList()[target];
+                TriggerClientEvent(player: targetPlayer, eventName: "vMenu:GoToPlayer", args: source.Handle);
+                return;
+            }
+            // todo: enjoy.
         }
         #endregion
 

--- a/vMenuServer/EventManager.cs
+++ b/vMenuServer/EventManager.cs
@@ -176,6 +176,7 @@ namespace vMenuServer
             // Misc Settings
             "MSMenu",
             "MSAll",
+            "MSClearArea",
             "MSTeleportToWp",
             "MSShowCoordinates",
             "MSShowLocation",
@@ -201,8 +202,6 @@ namespace vMenuServer
         /// </summary>
         public EventManager()
         {
-
-
             if (GetCurrentResourceName() != "vMenu")
             {
                 Exception InvalidNameException = new Exception("\r\n\r\n[vMenu] INSTALLATION ERROR!\r\nThe name of the resource is not valid. Please change the folder name from '" + GetCurrentResourceName() + "' to 'vMenu' (case sensitive) instead!\r\n\r\n\r\n");

--- a/vMenuServer/EventManager.cs
+++ b/vMenuServer/EventManager.cs
@@ -255,6 +255,10 @@ namespace vMenuServer
                     }
                 }
 
+                if ((GetConvar("vMenuDisableDynamicWeather", "false") ?? "false").ToLower() == "true")
+                {
+                    dynamicWeather = false;
+                }
                 Tick += WeatherLoop;
                 Tick += TimeLoop;
             }

--- a/vMenuServer/EventManager.cs
+++ b/vMenuServer/EventManager.cs
@@ -327,7 +327,7 @@ namespace vMenuServer
         /// </summary>
         private void RefreshWeather()
         {
-            var random = new Random().Next(10);
+            var random = new Random().Next(20);
             if (currentWeather == "RAIN" || currentWeather == "THUNDER")
             {
                 currentWeather = "CLEARING";
@@ -343,23 +343,35 @@ namespace vMenuServer
                     case 0:
                     case 1:
                     case 2:
-                        currentWeather = (currentWeather == "EXTRASUNNY" ? "CLEAR" : "EXTRASUNNY");
-                        break;
                     case 3:
-                        currentWeather = (currentWeather == "SMOG" ? "FOGGY" : "SMOG");
-                        break;
                     case 4:
                     case 5:
+                        currentWeather = (currentWeather == "EXTRASUNNY" ? "CLEAR" : "EXTRASUNNY");
+                        break;
                     case 6:
-                        currentWeather = (currentWeather == "CLOUDS" ? "OVERCAST" : "CLOUDS");
-                        break;
                     case 7:
-                        currentWeather = (currentWeather == "CLOUDS" ? "EXTRASUNNY" : "RAIN");
-                        break;
                     case 8:
-                        currentWeather = (currentWeather == "OVERCAST" ? "THUNDER" : "OVERCAST");
+                        currentWeather = (currentWeather == "SMOG" ? "FOGGY" : "SMOG");
                         break;
                     case 9:
+                    case 10:
+                    case 11:
+                        currentWeather = (currentWeather == "CLOUDS" ? "OVERCAST" : "CLOUDS");
+                        break;
+                    case 12:
+                    case 13:
+                    case 14:
+                        currentWeather = (currentWeather == "CLOUDS" ? "OVERCAST" : "CLOUDS");
+                        break;
+                    case 15:
+                        currentWeather = (currentWeather == "OVERCAST" ? "THUNDER" : "OVERCAST");
+                        break;
+                    case 16:
+                        currentWeather = (currentWeather == "CLOUDS" ? "EXTRASUNNY" : "RAIN");
+                        break;
+                    case 17:
+                    case 18:
+                    case 19:
                     default:
                         currentWeather = (currentWeather == "FOGGY" ? "SMOG" : "FOGGY");
                         break;

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -155,6 +155,7 @@ add_ace builtin.everyone "vMenu.WeaponOptions.All" allow
 # Misc Settings
 add_ace builtin.everyone "vMenu.MiscSettings.Menu" allow
 add_ace builtin.everyone "vMenu.MiscSettings.All" allow
+#add_ace builtin.everyone "vMenu.MiscSettings.ClearArea" allow
 #add_ace builtin.everyone "vMenu.MiscSettings.TeleportToWp" allow
 #add_ace builtin.everyone "vMenu.MiscSettings.ShowCoordinates" allow
 #add_ace builtin.everyone "vMenu.MiscSettings.ShowLocation" allow


### PR DESCRIPTION
**Added**
- 2a1fdde Clear Area option in Misc Settings (requires: `vMenu.MiscSettings.ClearArea` permission). It will clear the area around you (100 meters) of all damage to the world, objects, props, broken street lights (and similar world-details), vehicles, peds, etc, etc.
- 72d3fc9 Added a new convar (`set vMenuDisableDynamicWeather "true"`) that when set will disable dynamic weather changes by default when the server starts. It can still be turned on if players  have permission to toggle it, but it'll be disabled by default with this convar set.
- 706efdf Added the `KAMACHO`. Apparently this car was missing from the off-road category, but nobody noticed or bothered reporting it, so this has now been fixed.

**Changes**
- 3a0beb3 Changed the design of the Weapon Options menu. Every weapon is now in their correct Weapon Category. Reducing the 82 items long list in some better organized submenus. Full permissions support will be added soon.
- c0d8518 Changed the weather system to increase the chance of "good weather" and reduce the chance of "bad weather" (rain/thunder/overcast).
- 454703a Some internal cleaning up.

**Fixes and improvements**
- 9de2eea Fixed addon list permission bug for vehicle spawning. This list will now also check for vehicle classes permissions.
- 65ce0b5 Improved some "spacer items centering" internal functions (used in the new Weapon Options menu and the Vehicle Colors submenu).
- 087a589 Fixed/improved vehicle and player freezing/unfreezing, allowing for better compatibility with other resources relying on the player to be frozen without external resources trying to unfreeze the entity constantly.
- d1e5b0f Fixed an issue which allowed certain people who think they're cool abuse the kick/summon/kill options by injecting code into the game and creating fake events. It's unlikely this has been used a lot, if at all, so  it's nothing to worry about. Especially because it's now fixed 😊.
- c1e8aa8 Fixed saved vehicles being spawned multiple times when opening/closing the menu a lot and disabling "replace previous vehicle". Thanks to [Deltanic](https://github.com/Deltanic) for reporting this some time ago and helping me test/debug this issue.
- fa28ac9 Also reported by Deltanic, was that sometimes your car would not be deleted/placed on the ground correctly when already in a vehicle and spawning a new one. This is now changed so if you disabled "replace previous vehicle" and you spawn a new car while already being inside one, your old one won't be deleted and your new car will spawn in front of your old car.
