### PR TITLE
Add a key fob for the personal vehicle menu.

### DIFF
--- a/vMenu/menus/PersonalVehicle.cs
+++ b/vMenu/menus/PersonalVehicle.cs
@@ -17,7 +17,6 @@ namespace vMenuClient
     {
         // Variables
         private Menu menu;
-        private int KeyDelay = 1000;
         public bool EnableVehicleBlip { get; private set; } = UserDefaults.PVEnableVehicleBlip;
 
         // Empty constructor
@@ -300,7 +299,7 @@ namespace vMenuClient
             };
         }
 
-        private void PressKeyFob(Player player)
+        private async void PressKeyFob(Player player)
         {
             if(player != null && !player.IsDead && !player.Character.IsInVehicle())
             {
@@ -317,11 +316,13 @@ namespace vMenuClient
 
                 RequestAnimDict("anim@mp_player_intmenu@key_fob@");
                 while (!HasAnimDictLoaded("anim@mp_player_intmenu@key_fob@")) {
-                    Delay(time: 0);
+                    await Delay(0);
                 }
                 player.Character.Task.PlayAnimation("anim@mp_player_intmenu@key_fob@", "fob_click", 3f, 1000, AnimationFlags.UpperBodyOnly);
                 PlaySoundFromEntity(-1, "Remote_Control_Fob", player.Character.Handle, "PI_Menu_Sounds", true, 0);
             }
+
+            await Delay(0);
         }
 
         private async void SoundHorn(Vehicle veh)

--- a/vMenu/menus/PersonalVehicle.cs
+++ b/vMenu/menus/PersonalVehicle.cs
@@ -303,6 +303,16 @@ namespace vMenuClient
         {
             if(player != null && !player.IsDead && !player.Character.IsInVehicle())
             {
+                uint KeyFobHashKey = (uint)GetHashKey("p_car_keys_01");
+                RequestModel(KeyFobHashKey);
+                while(!HasModelLoaded(KeyFobHashKey))
+                {
+                    await Delay(0);
+                }
+
+                int KeyFobObject = CreateObject((int)KeyFobHashKey, 0, 0, 0, true, true, true);
+                AttachEntityToEntity(KeyFobObject, player.Character.Handle, GetPedBoneIndex(player.Character.Handle, 57005), 0.09f, 0.03f, -0.02f, -76f, 13f, 28f, false, true, true, true, 0, true);
+
                 ClearPedTasks(player.Character.Handle);
                 if(player.Character.Weapons.Current.Hash != WeaponHash.Unarmed)
                 {
@@ -320,6 +330,10 @@ namespace vMenuClient
                 }
                 player.Character.Task.PlayAnimation("anim@mp_player_intmenu@key_fob@", "fob_click", 3f, 1000, AnimationFlags.UpperBodyOnly);
                 PlaySoundFromEntity(-1, "Remote_Control_Fob", player.Character.Handle, "PI_Menu_Sounds", true, 0);
+
+                await Delay(1250);
+                DetachEntity(KeyFobObject, false, false);
+                DeleteObject(ref KeyFobObject);
             }
 
             await Delay(0);

--- a/vMenu/menus/PersonalVehicle.cs
+++ b/vMenu/menus/PersonalVehicle.cs
@@ -312,6 +312,7 @@ namespace vMenuClient
 
                 int KeyFobObject = CreateObject((int)KeyFobHashKey, 0, 0, 0, true, true, true);
                 AttachEntityToEntity(KeyFobObject, player.Character.Handle, GetPedBoneIndex(player.Character.Handle, 57005), 0.09f, 0.03f, -0.02f, -76f, 13f, 28f, false, true, true, true, 0, true);
+                SetModelAsNoLongerNeeded(KeyFobHashKey); // cleanup model from memory
 
                 ClearPedTasks(player.Character.Handle);
                 if(player.Character.Weapons.Current.Hash != WeaponHash.Unarmed)
@@ -324,16 +325,19 @@ namespace vMenuClient
                     TaskTurnPedToFaceEntity(player.Character.Handle, CurrentPersonalVehicle.Handle, 1000);
                 }
 
-                RequestAnimDict("anim@mp_player_intmenu@key_fob@");
-                while (!HasAnimDictLoaded("anim@mp_player_intmenu@key_fob@")) {
+                string animDict = "anim@mp_player_intmenu@key_fob@";
+                RequestAnimDict(animDict);
+                while (!HasAnimDictLoaded(animDict)) {
                     await Delay(0);
                 }
-                player.Character.Task.PlayAnimation("anim@mp_player_intmenu@key_fob@", "fob_click", 3f, 1000, AnimationFlags.UpperBodyOnly);
+                player.Character.Task.PlayAnimation(animDict, "fob_click", 3f, 1000, AnimationFlags.UpperBodyOnly);
                 PlaySoundFromEntity(-1, "Remote_Control_Fob", player.Character.Handle, "PI_Menu_Sounds", true, 0);
+                
 
                 await Delay(1250);
                 DetachEntity(KeyFobObject, false, false);
                 DeleteObject(ref KeyFobObject);
+                RemoveAnimDict(animDict); // cleanup anim dict from memory
             }
 
             await Delay(0);

--- a/vMenu/menus/PersonalVehicle.cs
+++ b/vMenu/menus/PersonalVehicle.cs
@@ -17,6 +17,7 @@ namespace vMenuClient
     {
         // Variables
         private Menu menu;
+        private int KeyDelay = 1000;
         public bool EnableVehicleBlip { get; private set; } = UserDefaults.PVEnableVehicleBlip;
 
         // Empty constructor
@@ -117,6 +118,7 @@ namespace vMenuClient
 
                     if (item == toggleLights)
                     {
+                        PressKeyFob(Game.Player);
                         if (itemIndex == 0)
                         {
                             SetVehicleLights(CurrentPersonalVehicle.Handle, 3);
@@ -267,22 +269,26 @@ namespace vMenuClient
 
                         if (item == toggleEngine)
                         {
+                            PressKeyFob(Game.Player);
                             SetVehicleEngineOn(CurrentPersonalVehicle.Handle, !CurrentPersonalVehicle.IsEngineRunning, true, true);
                         }
 
                         else if (item == lockDoors || item == unlockDoors)
                         {
+                            PressKeyFob(Game.Player);
                             bool _lock = item == lockDoors;
                             LockOrUnlockDoors(CurrentPersonalVehicle, _lock);
                         }
 
                         else if (item == soundHorn)
                         {
+                            PressKeyFob(Game.Player);
                             SoundHorn(CurrentPersonalVehicle);
                         }
 
                         else if (item == toggleAlarm)
                         {
+                            PressKeyFob(Game.Player);
                             ToggleVehicleAlarm(CurrentPersonalVehicle);
                         }
                     }
@@ -292,6 +298,30 @@ namespace vMenuClient
                     Notify.Error("You have not yet selected a personal vehicle, or your vehicle has been deleted. Set a personal vehicle before you can use these options.");
                 }
             };
+        }
+
+        private void PressKeyFob(Player player)
+        {
+            if(player != null && !player.IsDead && !player.Character.IsInVehicle())
+            {
+                ClearPedTasks(player.Character.Handle);
+                if(player.Character.Weapons.Current.Hash != WeaponHash.Unarmed)
+                {
+                    player.Character.Weapons.Give(WeaponHash.Unarmed, 1, true, true);
+                }
+
+                if (!HasEntityClearLosToEntityInFront(player.Character.Handle, CurrentPersonalVehicle.Handle))
+                {
+                    TaskTurnPedToFaceEntity(player.Character.Handle, CurrentPersonalVehicle.Handle, 1000);
+                }
+
+                RequestAnimDict("anim@mp_player_intmenu@key_fob@");
+                while (!HasAnimDictLoaded("anim@mp_player_intmenu@key_fob@")) {
+                    Delay(time: 0);
+                }
+                player.Character.Task.PlayAnimation("anim@mp_player_intmenu@key_fob@", "fob_click", 3f, 1000, AnimationFlags.UpperBodyOnly);
+                PlaySoundFromEntity(-1, "Remote_Control_Fob", player.Character.Handle, "PI_Menu_Sounds", true, 0);
+            }
         }
 
         private async void SoundHorn(Vehicle veh)


### PR DESCRIPTION
When options such as toggle engine, (un)lock doors, toggle lights, etc. are pressed, the player will now face towards the vehicle and press a key fob. It'll play a sound when doing so, much like the GTA:O system.

I attempted to make the key fob object exist but I couldn't be the positioning to be exactly in the right hand. If anyone can do it, they're more than welcome to.

The source & idea for this PR came from [this LSPD:FR script](https://www.lcpdfr.com/files/file/22203-vehicle-keys/).