### PR TITLE
[update]Use localized mod type name for mod options in VehicleOptions menu

### DIFF
--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1698,7 +1698,7 @@ namespace vMenuClient
                     veh = GetVehicle();
 
                     // Get the proper localized mod type (suspension, armor, etc) name.
-                    var typeName = ToProperString(mod.LocalizedModTypeName);
+                    var typeName = mod.LocalizedModTypeName;
 
                     // Create a list to all available upgrades for this modtype.
                     var modlist = new List<string>();

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1697,8 +1697,8 @@ namespace vMenuClient
                 {
                     veh = GetVehicle();
 
-                    // Get the mod type (suspension, armor, etc) name (convert the PascalCase to the Proper Case string values).
-                    var typeName = ToProperString(mod.ModType.ToString());
+                    // Get the proper localized mod type (suspension, armor, etc) name.
+                    var typeName = ToProperString(mod.LocalizedModTypeName);
 
                     // Create a list to all available upgrades for this modtype.
                     var modlist = new List<string>();

--- a/vMenu/vMenuClient.csproj
+++ b/vMenu/vMenuClient.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -106,8 +106,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CitizenFX.Core.Client">
-      <Version>1.0.1132</Version>
+      <Version>1.0.1159</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Use localized mod type name for mod options in VehicleOptions menu, this could be nice for non-English players :)
I've checked in game and most of the text are localized, however some are not. But this issue should be fix by fiveM team(or makes contribution to them).
Here's the screenshot:
![image](https://user-images.githubusercontent.com/20377660/55276363-fb85e280-532d-11e9-9863-30950fbe1ccb.png)
