### PR TITLE
Door locking mechanism change

### DIFF
--- a/SharedClasses/PermissionsManager.cs
+++ b/SharedClasses/PermissionsManager.cs
@@ -99,6 +99,7 @@ namespace vMenuShared
             VOFlashHighbeamsOnHonk,
             VODisableTurbulence,
             VOInfiniteFuel,
+            VOCruiseControl,
             VOFlares,
             VOPlaneBombs,
             #endregion

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -98,12 +98,12 @@ namespace vMenuClient
                 if (lockDoors)
                 {
                     Subtitle.Custom("Vehicle doors are now locked.");
-                    SetVehicleDoorsLockedForAllPlayers(veh.Handle, true);
+                    SetVehicleDoorsLocked(veh.Handle, 2);
                 }
                 else
                 {
                     Subtitle.Custom("Vehicle doors are now unlocked.");
-                    SetVehicleDoorsLockedForAllPlayers(veh.Handle, false);
+                    SetVehicleDoorsLocked(veh.Handle, 0);
                 }
             }
         }

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -449,6 +449,41 @@ namespace vMenuClient
                             }
                         }
 
+                        if (MainMenu.VehicleOptionsMenu.VehicleCruiseControl)
+                        {
+                            float cruiseSpeed = MainMenu.VehicleOptionsMenu.VehicleCruiseControlSpeed;
+                            float speed = GetEntitySpeedVector(veh.Handle, true).Y;
+
+
+                            if (veh.Model.IsHelicopter || cruiseSpeed < 0.01f || speed < 0.01f)
+                            {
+                                ((MenuCheckboxItem)MainMenu.VehicleOptionsMenu.GetMenu().GetMenuItems()
+                                    .Find(x => x.Text == "Cruise Control")).Checked = false;
+                                MainMenu.VehicleOptionsMenu.VehicleCruiseControl = false;
+                                MainMenu.VehicleOptionsMenu.VehicleCruiseControlSpeed = 0.0f;
+                            }
+
+                            bool inSeat = veh.Model.IsPlane || veh.GetPedOnSeat(VehicleSeat.Driver) == ped;
+                            bool isInAirOrUpsideDownIfCar = !veh.Model.IsPlane && (!veh.IsOnAllWheels || veh.IsInWater);
+
+                            if (!(!inSeat || isInAirOrUpsideDownIfCar))
+                            {
+                                if (veh.Exists() && MainMenu.VehicleOptionsMenu.VehicleCruiseControl)
+                                {
+                                    if (Math.Abs(speed - cruiseSpeed) < 2 * veh.MaxBraking)
+                                    {
+                                        SetVehicleForwardSpeed(veh.Handle,
+                                            MainMenu.VehicleOptionsMenu.VehicleCruiseControlSpeed);
+                                    }
+                                    else
+                                    {
+                                        SetVehicleForwardSpeed(veh.Handle,
+                                            speed + veh.Acceleration);
+                                    }
+                                }
+                            }
+                        }
+
                         await Delay(0);
                     }
                 }
@@ -483,6 +518,11 @@ namespace vMenuClient
                             Notify.Error(CommonErrors.NoVehicle, placeholderValue: "to access this menu");
                         }
                     }
+                    //Turn off cruise control
+                    ((MenuCheckboxItem)MainMenu.VehicleOptionsMenu.GetMenu().GetMenuItems()
+                        .Find(x => x.Text == "Cruise Control")).Checked = false;
+                    MainMenu.VehicleOptionsMenu.VehicleCruiseControl = false;
+                    MainMenu.VehicleOptionsMenu.VehicleCruiseControlSpeed = 0.0f;
                 }
 
                 await Delay(1);
@@ -573,11 +613,36 @@ namespace vMenuClient
                 }
                 return $"{color}{health}";
             }
-            if (MainMenu.PermissionsSetupComplete && MainMenu.VehicleOptionsMenu != null && MainMenu.VehicleOptionsMenu.VehicleShowHealth && veh != null && veh.Exists())
+            if (MainMenu.PermissionsSetupComplete && MainMenu.VehicleOptionsMenu != null)
             {
-                DrawTextOnScreen($"~n~Engine health: {GetHealthString(Math.Round(veh.EngineHealth, 2))}", 0.5f, 0.0f);
-                DrawTextOnScreen($"~n~~n~Body health: {GetHealthString(Math.Round(veh.BodyHealth, 2))}", 0.5f, 0.0f);
-                DrawTextOnScreen($"~n~~n~~n~Tank health: {GetHealthString(Math.Round(veh.PetrolTankHealth, 2))}", 0.5f, 0.0f);
+                if (MainMenu.VehicleOptionsMenu.VehicleShowHealth && veh != null && veh.Exists())
+                {
+                    DrawTextOnScreen($"~n~Engine health: {GetHealthString(Math.Round(veh.EngineHealth, 2))}", 0.5f,
+                        0.0f);
+                    DrawTextOnScreen($"~n~~n~Body health: {GetHealthString(Math.Round(veh.BodyHealth, 2))}", 0.5f,
+                        0.0f);
+                    DrawTextOnScreen($"~n~~n~~n~Tank health: {GetHealthString(Math.Round(veh.PetrolTankHealth, 2))}",
+                        0.5f, 0.0f);
+                }
+
+                if (IsPedInAnyVehicle(Game.PlayerPed.Handle, true) && IsAllowed(Permission.VOMenu) && veh != null &&
+                    veh.Exists())
+                {
+                    if (MainMenu.VehicleOptionsMenu.VehicleCruiseControl)
+                    {
+                        //INPUT_VEH_BRAKE = 72,
+                        if (Game.IsControlJustReleased(0, Control.VehicleBrake))
+                        {
+                            MainMenu.VehicleOptionsMenu.VehicleCruiseControlSpeed -= 2.0f / 3.6f;
+                        }
+
+                        //INPUT_VEH_ACCELERATE = 71,
+                        if (Game.IsControlJustReleased(0, Control.VehicleAccelerate))
+                        {
+                            MainMenu.VehicleOptionsMenu.VehicleCruiseControlSpeed += 2.0f / 3.6f;
+                        }
+                    }
+                }
             }
 
             await Task.FromResult(0);

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2906,7 +2906,8 @@ namespace vMenuClient
                                 // lock or unlock the vehicle
                                 PressKeyFob(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle);
                                 await Delay(100);
-                                bool lockDoors = !GetVehicleDoorsLockedForPlayer(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle.Handle, Game.PlayerPed.Handle);
+                                //Using the same integers as locking, 0 unlocked, 2 locked, 4 childlock
+                                bool lockDoors = GetVehicleDoorLockStatus(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle.Handle) != 2;
                                 LockOrUnlockDoors(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle, lockDoors);
 
                                 // reset the timer.

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -46,12 +46,14 @@ namespace vMenuClient
         public bool DisablePlaneTurbulence { get; private set; } = UserDefaults.VehicleDisablePlaneTurbulence;
         public bool VehicleBikeSeatbelt { get; private set; } = UserDefaults.VehicleBikeSeatbelt;
         public bool VehicleInfiniteFuel { get; private set; } = false;
+        public bool VehicleCruiseControl { get; set; } = false;
         public bool VehicleShowHealth { get; private set; } = false;
         public bool VehicleFrozen { get; private set; } = false;
         public bool VehicleTorqueMultiplier { get; private set; } = false;
         public bool VehiclePowerMultiplier { get; private set; } = false;
         public float VehicleTorqueMultiplierAmount { get; private set; } = 2f;
         public float VehiclePowerMultiplierAmount { get; private set; } = 2f;
+        public float VehicleCruiseControlSpeed { get; set; } = 0f;
 
         private Dictionary<MenuItem, int> vehicleExtras = new Dictionary<MenuItem, int>();
         #endregion
@@ -85,6 +87,7 @@ namespace vMenuClient
             MenuCheckboxItem highbeamsOnHonk = new MenuCheckboxItem("Flash Highbeams On Honk", "Turn on your highbeams on your vehicle when honking your horn. Does not work during the day when you have your lights turned off.", FlashHighbeamsOnHonk);
             MenuCheckboxItem showHealth = new MenuCheckboxItem("Show Vehicle Health", "Shows the vehicle health on the screen.", VehicleShowHealth);
             MenuCheckboxItem infiniteFuel = new MenuCheckboxItem("Infinite Fuel", "Enables or disables infinite fuel for this vehicle, only works if FRFuel is installed.", VehicleInfiniteFuel);
+            MenuCheckboxItem cruiseControl = new MenuCheckboxItem("Cruise Control", "Enables or disables cruise control.", VehicleCruiseControl);
 
             // Create buttons.
             MenuItem fixVehicle = new MenuItem("Repair Vehicle", "Repair any visual and physical damage present on your vehicle.");
@@ -367,6 +370,10 @@ namespace vMenuClient
             {
                 menu.AddMenuItem(infiniteFuel);
             }
+            if (IsAllowed(Permission.VOCruiseControl))
+            {
+                menu.AddMenuItem(cruiseControl);
+            }
             // always allowed
             menu.AddMenuItem(showHealth); // SHOW VEHICLE HEALTH
 
@@ -616,6 +623,14 @@ namespace vMenuClient
                 else if (item == infiniteFuel)
                 {
                     VehicleInfiniteFuel = _checked;
+                }
+                else if (item == cruiseControl)
+                {
+                    VehicleCruiseControl = _checked;
+                    if (_checked && vehicle != null && vehicle.Exists())
+                    {
+                        VehicleCruiseControlSpeed = GetEntitySpeedVector(vehicle.Handle, true).Y;
+                    }
                 }
             };
             #endregion


### PR DESCRIPTION
Originally, the method SetVehicleDoorsLockedForAllPlayers was used to lock car doors. However, whenever a driver was inside the car and a passenger attempted to enter a locked car, the passenger would smash the window, open the door, attempt to get in, and instantly get kicked outside. Menyoo (the client side mod) was able to lock doors without this issue. Diving into his codebase, he uses the method SetVehicleDoorsLocked, where 0 == unlocked, 2 == locked and 4 == childlock (childlock meaning you can't leave when locked, while 2 allows you to leave a locked vehicle but not reenter). Changing the LockOrUnlockDoors method with this new method, and making sure the "double click E to lock/Unlock" methods are changed, the functionality fully works as expected.