### PR TITLE
VehicleSpawnerRadioOff

### DIFF
--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1065,7 +1065,7 @@ namespace vMenuClient
                 {
                     // Convert it into a model hash.
                     uint model = (uint)GetHashKey(result);
-                    SpawnVehicle(vehicleHash: model, spawnInside: spawnInside, replacePrevious: replacePrevious, turnOffRadio:turnOffRadio, skipLoad: false, vehicleInfo: new VehicleInfo(),
+                    SpawnVehicle(vehicleHash: model, spawnInside: spawnInside, replacePrevious: replacePrevious, turnOffRadio: turnOffRadio, skipLoad: false, vehicleInfo: new VehicleInfo(),
                         saveName: null);
                 }
                 // Result was invalid.

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1054,7 +1054,7 @@ namespace vMenuClient
         /// <param name="vehicleName">Vehicle model name. If "custom" the user will be asked to enter a model name.</param>
         /// <param name="spawnInside">Warp the player inside the vehicle after spawning.</param>
         /// <param name="replacePrevious">Replace the previous vehicle of the player.</param>
-        public static async void SpawnVehicle(string vehicleName = "custom", bool spawnInside = false, bool replacePrevious = false)
+        public static async void SpawnVehicle(string vehicleName = "custom", bool spawnInside = false, bool replacePrevious = false, bool turnOffRadio = false)
         {
             if (vehicleName == "custom")
             {
@@ -1065,7 +1065,7 @@ namespace vMenuClient
                 {
                     // Convert it into a model hash.
                     uint model = (uint)GetHashKey(result);
-                    SpawnVehicle(vehicleHash: model, spawnInside: spawnInside, replacePrevious: replacePrevious, skipLoad: false, vehicleInfo: new VehicleInfo(),
+                    SpawnVehicle(vehicleHash: model, spawnInside: spawnInside, replacePrevious: replacePrevious, turnOffRadio:turnOffRadio, skipLoad: false, vehicleInfo: new VehicleInfo(),
                         saveName: null);
                 }
                 // Result was invalid.
@@ -1077,7 +1077,7 @@ namespace vMenuClient
             // Spawn the specified vehicle.
             else
             {
-                SpawnVehicle(vehicleHash: (uint)GetHashKey(vehicleName), spawnInside: spawnInside, replacePrevious: replacePrevious, skipLoad: false,
+                SpawnVehicle(vehicleHash: (uint)GetHashKey(vehicleName), spawnInside: spawnInside, replacePrevious: replacePrevious, turnOffRadio: turnOffRadio, skipLoad: false,
                     vehicleInfo: new VehicleInfo(), saveName: null);
             }
         }
@@ -1093,7 +1093,7 @@ namespace vMenuClient
         /// <param name="skipLoad">Does not attempt to load the vehicle, but will spawn it right a way.</param>
         /// <param name="vehicleInfo">All information needed for a saved vehicle to re-apply all mods.</param>
         /// <param name="saveName">Used to get/set info about the saved vehicle data.</param>
-        public static async void SpawnVehicle(uint vehicleHash, bool spawnInside, bool replacePrevious, bool skipLoad, VehicleInfo vehicleInfo, string saveName = null)
+        public static async void SpawnVehicle(uint vehicleHash, bool spawnInside, bool replacePrevious, bool skipLoad, VehicleInfo vehicleInfo, string saveName = null, bool turnOffRadio = false)
         {
             float speed = 0f;
             float rpm = 0f;
@@ -1194,7 +1194,7 @@ namespace vMenuClient
                 PreviouslyOwnedByPlayer = true,
                 IsPersistent = true,
                 IsStolen = false,
-                IsWanted = false
+                IsWanted = false,
             };
 
             Log($"New vehicle, hash:{vehicleHash}, handle:{vehicle.Handle}, force-re-save-name:{(saveName ?? "NONE")}, created at x:{pos.X} y:{pos.Y} z:{(pos.Z + 1f)} " +
@@ -1219,6 +1219,13 @@ namespace vMenuClient
                 {
                     vehicle.PlaceOnGround();
                 }
+            }
+
+            // If turnOffRadio is true
+            if (turnOffRadio)
+            {
+                // Set vehicle's radio station to off.
+                vehicle.RadioStation = RadioStation.RadioOff;
             }
 
             // If mod info about the vehicle was specified, check if it's not null.

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1194,7 +1194,7 @@ namespace vMenuClient
                 PreviouslyOwnedByPlayer = true,
                 IsPersistent = true,
                 IsStolen = false,
-                IsWanted = false,
+                IsWanted = false
             };
 
             Log($"New vehicle, hash:{vehicleHash}, handle:{vehicle.Handle}, force-re-save-name:{(saveName ?? "NONE")}, created at x:{pos.X} y:{pos.Y} z:{(pos.Z + 1f)} " +

--- a/vMenu/UserDefaults.cs
+++ b/vMenu/UserDefaults.cs
@@ -173,6 +173,12 @@ namespace vMenuClient
             get { return GetSettingsBool("vehicleSpawnerReplacePrevious"); }
             set { SetSavedSettingsBool("vehicleSpawnerReplacePrevious", value); }
         }
+
+        public static bool VehicleSpawnerTurnOffRadio
+        {
+            get { return GetSettingsBool("vehicleSpawnerTurnOffRadio"); }
+            set { SetSavedSettingsBool("vehicleSpawnerTurnOffRadio", value); }
+        }
         #endregion
 
         #region Weapon Options
@@ -639,6 +645,9 @@ namespace vMenuClient
 
                 VehicleSpawnerSpawnInside = MainMenu.VehicleSpawnerMenu.SpawnInVehicle;
                 prefs.Add("vehicleSpawnerSpawnInside", VehicleSpawnerSpawnInside);
+
+                VehicleSpawnerTurnOffRadio = MainMenu.VehicleSpawnerMenu.TurnOffRadio;
+                prefs.Add("vehicleSpawnerTurnOffRadio", VehicleSpawnerTurnOffRadio);
             }
 
             if (MainMenu.VoiceChatSettingsMenu != null)

--- a/vMenu/menus/VehicleSpawner.cs
+++ b/vMenu/menus/VehicleSpawner.cs
@@ -21,6 +21,7 @@ namespace vMenuClient
 
         public bool SpawnInVehicle { get; private set; } = UserDefaults.VehicleSpawnerSpawnInside;
         public bool ReplaceVehicle { get; private set; } = UserDefaults.VehicleSpawnerReplacePrevious;
+        public bool TurnOffRadio { get; private set; } = UserDefaults.VehicleSpawnerTurnOffRadio;
         public static List<bool> allowedCategories;
 
         private void CreateMenu()
@@ -33,6 +34,7 @@ namespace vMenuClient
             MenuItem spawnByName = new MenuItem("Spawn Vehicle By Model Name", "Enter the name of a vehicle to spawn.");
             MenuCheckboxItem spawnInVeh = new MenuCheckboxItem("Spawn Inside Vehicle", "This will teleport you into the vehicle when you spawn it.", SpawnInVehicle);
             MenuCheckboxItem replacePrev = new MenuCheckboxItem("Replace Previous Vehicle", "This will automatically delete your previously spawned vehicle when you spawn a new vehicle.", ReplaceVehicle);
+            MenuCheckboxItem turnOffRad = new MenuCheckboxItem("Turn Off Radio", "This will automatically turn off vehicle radio when you spawn a new vehicle.", TurnOffRadio);
 
             // Add the items to the menu.
             if (IsAllowed(Permission.VSSpawnByName))
@@ -41,6 +43,7 @@ namespace vMenuClient
             }
             menu.AddMenuItem(spawnInVeh);
             menu.AddMenuItem(replacePrev);
+            menu.AddMenuItem(turnOffRad);
             #endregion
 
             #region addon cars menu
@@ -114,7 +117,7 @@ namespace vMenuClient
 
                                 categoryMenu.OnItemSelect += (sender, item, index) =>
                                 {
-                                    SpawnVehicle(item.ItemData.ToString(), SpawnInVehicle, ReplaceVehicle);
+                                    SpawnVehicle(item.ItemData.ToString(), SpawnInVehicle, ReplaceVehicle, TurnOffRadio);
                                 };
                             }
                             else
@@ -268,7 +271,7 @@ namespace vMenuClient
                 // Handle button presses
                 vehicleClassMenu.OnItemSelect += (sender2, item2, index2) =>
                 {
-                    SpawnVehicle(VehicleData.Vehicles.VehicleClasses[className][index2], SpawnInVehicle, ReplaceVehicle);
+                    SpawnVehicle(VehicleData.Vehicles.VehicleClasses[className][index2], SpawnInVehicle, ReplaceVehicle, TurnOffRadio);
                 };
             }
             #endregion
@@ -280,7 +283,7 @@ namespace vMenuClient
                 if (item == spawnByName)
                 {
                     // Passing "custom" as the vehicle name, will ask the user for input.
-                    SpawnVehicle("custom", SpawnInVehicle, ReplaceVehicle);
+                    SpawnVehicle("custom", SpawnInVehicle, ReplaceVehicle, TurnOffRadio);
                 }
             };
 
@@ -294,6 +297,10 @@ namespace vMenuClient
                 else if (item == replacePrev)
                 {
                     ReplaceVehicle = _checked;
+                }
+                else if (item == turnOffRad)
+                {
+                    TurnOffRadio = _checked;
                 }
             };
             #endregion


### PR DESCRIPTION
Hi, I added a checkbox to vehicle spawner menu for turn off vehicle radio when you spawn a new vehicle.

When vMenu is on, we can't turn off the radio by pressing the "Q", so if I don't want to listen to the radio when spawning cars, I have to turn vMenu off and on every time. With this feature, you don't have to do it, if checkbox checks, vehicle radio automatically turn off when you spawn a new vehicle.