### PR TITLE
Fix NoClip: Alpha Reset

### DIFF
--- a/vMenu/Noclip.cs
+++ b/vMenu/Noclip.cs
@@ -221,7 +221,7 @@ namespace vMenuClient
 
                 SetEntityVisible(noclipEntity, true, false);
                 SetLocalPlayerVisibleLocally(true);
-                SetEntityAlpha(noclipEntity, 255, 0);
+                ResetEntityAlpha(noclipEntity);
 
                 SetEveryoneIgnorePlayer(Game.PlayerPed.Handle, false);
                 SetPoliceIgnorePlayer(Game.PlayerPed.Handle, false);


### PR DESCRIPTION
Alpha Reset when leaving vMenu seems like it's not working properly.  It's always a bit translucent in a certain angle.

See Screenshot: https://media.discordapp.net/attachments/450691447021371392/623204144336863232/unknown.png