### PR TITLE
Add new MiscSettings item to toggle playerblips on the minimap

### DIFF
--- a/SharedClasses/PermissionsManager.cs
+++ b/SharedClasses/PermissionsManager.cs
@@ -317,6 +317,7 @@ namespace vMenuShared
             MSThermalVision,
             MSLocationBlips,
             MSPlayerBlips,
+            MSPlayerBlipsMinimap,
             MSOverheadNames,
             MSTeleportLocations,
             MSTeleportSaveLocation,

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2237,6 +2237,7 @@ namespace vMenuClient
                     if (MainMenu.MiscSettingsMenu != null)
                     {
                         bool enabled = MainMenu.MiscSettingsMenu.ShowPlayerBlips && IsAllowed(Permission.MSPlayerBlips);
+                        bool minimapEnabled = MainMenu.MiscSettingsMenu.ShowPlayerBlipsMinimap && IsAllowed(Permission.MSPlayerBlipsMinimap);
 
                         foreach (Player p in MainMenu.PlayersList)
                         {
@@ -2262,7 +2263,7 @@ namespace vMenuClient
                                             blip = AddBlipForEntity(ped);
                                         }
                                         // only manage the blip for this player if the player is nearby
-                                        if (p.Character.Position.DistanceToSquared2D(Game.PlayerPed.Position) < 500000 || Game.IsPaused)
+                                        if (minimapEnabled && (p.Character.Position.DistanceToSquared2D(Game.PlayerPed.Position) < 500000 || Game.IsPaused))
                                         {
                                             // (re)set the blip color in case something changed it.
                                             SetBlipColour(blip, 0);

--- a/vMenu/UserDefaults.cs
+++ b/vMenu/UserDefaults.cs
@@ -244,6 +244,12 @@ namespace vMenuClient
             set { SetSavedSettingsBool("miscShowPlayerBlips", value); }
         }
 
+        public static bool MiscShowPlayerBlipsMinimap
+        {
+            get { return GetSettingsBool("miscShowPlayerBlipsMinimap"); }
+            set { SetSavedSettingsBool("miscShowPlayerBlipsMinimap", value); }
+        }
+
         public static bool MiscShowOverheadNames
         {
             get { return GetSettingsBool("miscShowOverheadNames"); }
@@ -548,6 +554,9 @@ namespace vMenuClient
 
                 MiscShowPlayerBlips = MainMenu.MiscSettingsMenu.ShowPlayerBlips;
                 prefs.Add("miscShowPlayerBlips", MiscShowPlayerBlips);
+
+                MiscShowPlayerBlipsMinimap = MainMenu.MiscSettingsMenu.ShowPlayerBlipsMinimap;
+                prefs.Add("miscShowPlayerBlipsMinimap", MiscShowPlayerBlipsMinimap);
 
                 MiscShowOverheadNames = MainMenu.MiscSettingsMenu.MiscShowOverheadNames;
                 prefs.Add("miscShowOverheadNames", MiscShowOverheadNames);

--- a/vMenu/menus/MiscSettings.cs
+++ b/vMenu/menus/MiscSettings.cs
@@ -32,6 +32,7 @@ namespace vMenuClient
         public bool LockCameraY { get; private set; } = false;
         public bool ShowLocationBlips { get; private set; } = UserDefaults.MiscLocationBlips;
         public bool ShowPlayerBlips { get; private set; } = UserDefaults.MiscShowPlayerBlips;
+        public bool ShowPlayerBlipsMinimap { get; private set; } = UserDefaults.MiscShowPlayerBlipsMinimap;
         public bool MiscShowOverheadNames { get; private set; } = UserDefaults.MiscShowOverheadNames;
         public bool ShowVehicleModelDimensions { get; private set; } = false;
         public bool ShowPedModelDimensions { get; private set; } = false;
@@ -158,6 +159,7 @@ namespace vMenuClient
 
             MenuCheckboxItem locationBlips = new MenuCheckboxItem("Location Blips", "Shows blips on the map for some common locations.", ShowLocationBlips);
             MenuCheckboxItem playerBlips = new MenuCheckboxItem("Show Player Blips", "Shows blips on the map for all players.", ShowPlayerBlips);
+            MenuCheckboxItem playerBlipsMinimap = new MenuCheckboxItem("Show Player Blips on Minimap", "Shows blips on the the minimap for all players. ~r~Requires Show Player Blips to be enabled!", ShowPlayerBlipsMinimap);
             MenuCheckboxItem playerNames = new MenuCheckboxItem("Show Player Names", "Enables or disables player overhead names.", MiscShowOverheadNames);
             MenuCheckboxItem respawnDefaultCharacter = new MenuCheckboxItem("Respawn As Default MP Character", "If you enable this, then you will (re)spawn as your default saved MP character. Note the server owner can globally disable this option. To set your default character, go to one of your saved MP Characters and click the 'Set As Default Character' button.", MiscRespawnDefaultCharacter);
             MenuCheckboxItem restorePlayerAppearance = new MenuCheckboxItem("Restore Player Appearance", "Restore your player's skin whenever you respawn after being dead. Re-joining a server will not restore your previous skin.", RestorePlayerAppearance);
@@ -555,6 +557,10 @@ namespace vMenuClient
             {
                 menu.AddMenuItem(playerBlips);
             }
+            if (IsAllowed(Permission.MSPlayerBlipsMinimap))
+            {
+                menu.AddMenuItem(playerBlipsMinimap);
+            }
             if (IsAllowed(Permission.MSOverheadNames))
             {
                 menu.AddMenuItem(playerNames);
@@ -667,6 +673,10 @@ namespace vMenuClient
                 else if (item == playerBlips)
                 {
                     ShowPlayerBlips = _checked;
+                }
+                else if (item == playerBlipsMinimap)
+                {
+                    ShowPlayerBlipsMinimap = _checked;
                 }
                 else if (item == playerNames)
                 {

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -498,6 +498,7 @@ add_ace builtin.everyone "vMenu.MiscSettings.ThermalVision" allow
 add_ace builtin.everyone "vMenu.MiscSettings.LocationBlips" allow
 add_ace builtin.everyone "vMenu.MiscSettings.OverheadNames" allow
 add_ace builtin.everyone "vMenu.MiscSettings.PlayerBlips" allow
+add_ace builtin.everyone "vMenu.MiscSettings.PlayerBlipsMinimap" allow
 add_ace builtin.everyone "vMenu.MiscSettings.TeleportLocations" allow
 add_ace group.moderator "vMenu.MiscSettings.TeleportSaveLocation" allow # Only allowed for moderators by default
 add_ace builtin.everyone "vMenu.MiscSettings.ConnectionMenu" allow


### PR DESCRIPTION
This merge adds another option to the MiscSettings menu that allows specifying permissions to view items on the minimap.

Not only does this allow server owners to restrict it from the minimap, but it also allows people to disable it on their minimap but keeping it active on their main overview map, which a lot of people prefer to reduce the metagaming of constantly seeing people on their minimap.