### PR TITLE
Add a get-in check for locking your personal vehicle

### DIFF
--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2861,7 +2861,7 @@ namespace vMenuClient
         {
             if (MainMenu.PermissionsSetupComplete && MainMenu.PersonalVehicleMenu != null && IsAllowed(Permission.PVLockDoors) && MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle != null)
             {
-                if (!Game.PlayerPed.IsInVehicle(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle))
+                if (!Game.PlayerPed.IsInVehicle(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle) && !Game.PlayerPed.IsGettingIntoAVehicle)
                 {
                     if (Game.PlayerPed.Position.DistanceToSquared(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle.Position) < 30.0f)
                     {


### PR DESCRIPTION
Simply adding a check to see if the player is currently trying to enter any vehicle. If you try to enter the vehicle you are currently locking, it can have some pretty... unexpected... consequences.

[Example video](https://streamable.com/0a7z9o) of problem

I found this pretty funny, but it's also an easy fix so I made a pull request.