### PR TITLE
Fix for player overhead names not disapearing.

### DIFF
--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2347,6 +2347,7 @@ namespace vMenuClient
                     {
                         RemoveMpGamerTag(gamerTag.Value);
                     }
+                    gamerTags.clear();
                 }
                 else
                 {

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2343,9 +2343,9 @@ namespace vMenuClient
                 bool enabled = MainMenu.MiscSettingsMenu.MiscShowOverheadNames && IsAllowed(Permission.MSOverheadNames);
                 if (!enabled)
                 {
-                    for (var i = 0; i < 255; i++)
+                    foreach (KeyValuePair<Player, int> gamerTag in gamerTags)
                     {
-                        RemoveMpGamerTag(i);
+                        RemoveMpGamerTag(gamerTag.Value);
                     }
                 }
                 else


### PR DESCRIPTION
For some reason in the code there was a for loop to iterate over players and not over the created gamertags dict. This resulted in mp gamer tags not disaprearing when checkbox unchecked.