### PR TITLE
Added  drawing of Network Owner to  developer tools

### DIFF
--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1237,6 +1237,11 @@ namespace vMenuClient
             }
             vehicle.CurrentRPM = rpm;
 
+            await Delay(1); // Mandatory delay - without it radio station will not set properly
+            
+            // Set the radio station to default set by player in Vehicle Menu
+            vehicle.RadioStation = (RadioStation)UserDefaults.VehicleDefaultRadio;
+
             // Discard the model.
             SetModelAsNoLongerNeeded(vehicleHash);
         }

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2679,6 +2679,19 @@ namespace vMenuClient
                             DrawTextOnScreen($"Hash {hashes}", 0f, 0f, 0.3f, Alignment.Center, 0);
                             ClearDrawOrigin();
                         }
+                        if (MainMenu.MiscSettingsMenu.ShowEntityNetOwners && v.IsOnScreen)
+                        {
+                            int netOwnerLocalId = NetworkGetEntityOwner(v.Handle);
+
+                            if (netOwnerLocalId != 0)
+                            {
+                                int playerServerId = GetPlayerServerId(netOwnerLocalId);
+                                string playerName = GetPlayerName(netOwnerLocalId);
+                                SetDrawOrigin(v.Position.X, v.Position.Y, v.Position.Z + 0.3f, 0);
+                                DrawTextOnScreen($"Owner ID {playerServerId} ({playerName})", 0f, 0f, 0.3f, Alignment.Center, 0);
+                                ClearDrawOrigin();
+                            }
+                        }
                     }
                 }
 
@@ -2711,6 +2724,20 @@ namespace vMenuClient
                             DrawTextOnScreen($"Hash {hashes}", 0f, 0f, 0.3f, Alignment.Center, 0);
                             ClearDrawOrigin();
                         }
+                        
+                        if (MainMenu.MiscSettingsMenu.ShowEntityNetOwners && p.IsOnScreen)
+                        {
+                            int netOwnerLocalId = NetworkGetEntityOwner(p.Handle);
+
+                            if (netOwnerLocalId != 0)
+                            {
+                                int playerServerId = GetPlayerServerId(netOwnerLocalId);
+                                string playerName = GetPlayerName(netOwnerLocalId);
+                                SetDrawOrigin(p.Position.X, p.Position.Y, p.Position.Z + 0.3f, 0);
+                                DrawTextOnScreen($"Owner ID {playerServerId} ({playerName})", 0f, 0f, 0.3f, Alignment.Center, 0);
+                                ClearDrawOrigin();
+                            }
+                        }
                     }
                 }
 
@@ -2742,6 +2769,20 @@ namespace vMenuClient
 
                             DrawTextOnScreen($"Hash {hashes}", 0f, 0f, 0.3f, Alignment.Center, 0);
                             ClearDrawOrigin();
+                        }
+                        
+                        if (MainMenu.MiscSettingsMenu.ShowEntityNetOwners && p.IsOnScreen)
+                        {
+                            int netOwnerLocalId = NetworkGetEntityOwner(p.Handle);
+
+                            if (netOwnerLocalId != 0)
+                            {
+                                int playerServerId = GetPlayerServerId(netOwnerLocalId);
+                                string playerName = GetPlayerName(netOwnerLocalId);
+                                SetDrawOrigin(p.Position.X, p.Position.Y, p.Position.Z + 0.3f, 0);
+                                DrawTextOnScreen($"Owner ID {playerServerId} ({playerName})", 0f, 0f, 0.3f, Alignment.Center, 0);
+                                ClearDrawOrigin();
+                            }
                         }
                     }
                 }

--- a/vMenu/UserDefaults.cs
+++ b/vMenu/UserDefaults.cs
@@ -159,6 +159,12 @@ namespace vMenuClient
             get { return GetSettingsBool("vehicleBikeSeatbelt"); }
             set { SetSavedSettingsBool("vehicleBikeSeatbelt", value); }
         }
+        
+        public static int VehicleDefaultRadio
+        {
+            get { return GetSettingsInt("vehicleDefaultRadio"); }
+            set { SetSavedSettingsInt("vehicleDefaultRadio", value); }
+        }
         #endregion
 
         #region Vehicle Spawner Options

--- a/vMenu/menus/MiscSettings.cs
+++ b/vMenu/menus/MiscSettings.cs
@@ -35,6 +35,7 @@ namespace vMenuClient
         public bool ShowPropModelDimensions { get; private set; } = false;
         public bool ShowEntityHandles { get; private set; } = false;
         public bool ShowEntityModels { get; private set; } = false;
+        public bool ShowEntityNetOwners { get; private set; } = false;
         public bool MiscRespawnDefaultCharacter { get; private set; } = UserDefaults.MiscRespawnDefaultCharacter;
         public bool RestorePlayerAppearance { get; private set; } = UserDefaults.MiscRestorePlayerAppearance;
         public bool RestorePlayerWeapons { get; private set; } = UserDefaults.MiscRestorePlayerWeapons;
@@ -126,6 +127,7 @@ namespace vMenuClient
             MenuCheckboxItem pedModelDimensions = new MenuCheckboxItem("Show Ped Dimensions", "Draws the model outlines for every ped that's currently close to you.", ShowPedModelDimensions);
             MenuCheckboxItem showEntityHandles = new MenuCheckboxItem("Show Entity Handles", "Draws the the entity handles for all close entities (you must enable the outline functions above for this to work).", ShowEntityHandles);
             MenuCheckboxItem showEntityModels = new MenuCheckboxItem("Show Entity Models", "Draws the the entity models for all close entities (you must enable the outline functions above for this to work).", ShowEntityModels);
+            MenuCheckboxItem showEntityNetOwners = new MenuCheckboxItem("Show Network Owners", "Draws the the entity net owner for all close entities (you must enable the outline functions above for this to work).", ShowEntityNetOwners);
             MenuSliderItem dimensionsDistanceSlider = new MenuSliderItem("Show Dimensions Radius", "Show entity model/handle/dimension draw range.", 0, 20, 20, false);
 
             MenuItem clearArea = new MenuItem("Clear Area", "Clears the area around your player (100 meters). Damage, dirt, peds, props, vehicles, etc. Everything gets cleaned up, fixed and reset to the default world state.");
@@ -403,6 +405,7 @@ namespace vMenuClient
                 developerToolsMenu.AddMenuItem(pedModelDimensions);
                 developerToolsMenu.AddMenuItem(showEntityHandles);
                 developerToolsMenu.AddMenuItem(showEntityModels);
+                developerToolsMenu.AddMenuItem(showEntityNetOwners);
                 developerToolsMenu.AddMenuItem(dimensionsDistanceSlider);
             }
 
@@ -478,6 +481,10 @@ namespace vMenuClient
                 else if (item == showEntityModels)
                 {
                     ShowEntityModels = _checked;
+                }
+                else if (item == showEntityNetOwners)
+                {
+                    ShowEntityNetOwners = _checked;
                 }
                 else if (item == enableTimeCycle)
                 {

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -134,6 +134,21 @@ namespace vMenuClient
             };
             MenuListItem vehicleLights = new MenuListItem("Vehicle Lights", lights, 0, "Turn vehicle lights on/off.");
 
+            List<string> stationNames = new List<string>();
+            
+            foreach (var radioStationName in Enum.GetNames(typeof(RadioStation)))
+            {
+                stationNames.Add(radioStationName);
+            }
+
+            int radioIndex = UserDefaults.VehicleDefaultRadio;
+
+            if (radioIndex == 255) // 255 is radio off
+            {
+                radioIndex = Enum.GetValues(typeof(RadioStation)).Length -1; // the last item is Radio off
+            }
+            
+            MenuListItem radioStations = new MenuListItem("Default radio station", stationNames, radioIndex, "Select a defalut radio station to be set when spawning new car");
 
             var tiresList = new List<string>() { "All Tires", "Tire #1", "Tire #2", "Tire #3", "Tire #4", "Tire #5", "Tire #6", "Tire #7", "Tire #8" };
             MenuListItem vehicleTiresList = new MenuListItem("Fix / Destroy Tires", tiresList, 0, "Fix or destroy a specific vehicle tire, or all of them at once. Note, not all indexes are valid for all vehicles, some might not do anything on certain vehicles.");
@@ -369,6 +384,9 @@ namespace vMenuClient
             }
             // always allowed
             menu.AddMenuItem(showHealth); // SHOW VEHICLE HEALTH
+            
+            // I don't really see why would you want to disable this so I will not add useless permissions
+            menu.AddMenuItem(radioStations);
 
             if (IsAllowed(Permission.VONoSiren) && !vMenuShared.ConfigManager.GetSettingsBool(vMenuShared.ConfigManager.Setting.vmenu_use_els_compatibility_mode)) // DISABLE SIREN
             {
@@ -897,6 +915,17 @@ namespace vMenuClient
                     {
                         Notify.Error(CommonErrors.NoVehicle);
                     }
+                } else if (item == radioStations)
+                {
+                    RadioStation newStation = (RadioStation)Enum.GetValues(typeof(RadioStation)).GetValue(listIndex);
+                    
+                    var veh = GetVehicle();
+                    if (veh != null && veh.Exists())
+                    {
+                        veh.RadioStation = newStation;
+                    }
+
+                    UserDefaults.VehicleDefaultRadio = (int) newStation;
                 }
             };
             #endregion


### PR DESCRIPTION
Added "Show Network Owners" to Developer Tools submenu. Draws server ID and player name of network owner on  closest entities like handles and models.