### PR TITLE
Drawing of NetOwners to developer menu

### DIFF
--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2679,6 +2679,19 @@ namespace vMenuClient
                             DrawTextOnScreen($"Hash {hashes}", 0f, 0f, 0.3f, Alignment.Center, 0);
                             ClearDrawOrigin();
                         }
+                        if (MainMenu.MiscSettingsMenu.ShowEntityNetOwners && v.IsOnScreen)
+                        {
+                            int netOwnerLocalId = NetworkGetEntityOwner(v.Handle);
+
+                            if (netOwnerLocalId != 0)
+                            {
+                                int playerServerId = GetPlayerServerId(netOwnerLocalId);
+                                string playerName = GetPlayerName(netOwnerLocalId);
+                                SetDrawOrigin(v.Position.X, v.Position.Y, v.Position.Z + 0.3f, 0);
+                                DrawTextOnScreen($"Owner ID {playerServerId} ({playerName})", 0f, 0f, 0.3f, Alignment.Center, 0);
+                                ClearDrawOrigin();
+                            }
+                        }
                     }
                 }
 
@@ -2711,6 +2724,20 @@ namespace vMenuClient
                             DrawTextOnScreen($"Hash {hashes}", 0f, 0f, 0.3f, Alignment.Center, 0);
                             ClearDrawOrigin();
                         }
+                        
+                        if (MainMenu.MiscSettingsMenu.ShowEntityNetOwners && p.IsOnScreen)
+                        {
+                            int netOwnerLocalId = NetworkGetEntityOwner(p.Handle);
+
+                            if (netOwnerLocalId != 0)
+                            {
+                                int playerServerId = GetPlayerServerId(netOwnerLocalId);
+                                string playerName = GetPlayerName(netOwnerLocalId);
+                                SetDrawOrigin(p.Position.X, p.Position.Y, p.Position.Z + 0.3f, 0);
+                                DrawTextOnScreen($"Owner ID {playerServerId} ({playerName})", 0f, 0f, 0.3f, Alignment.Center, 0);
+                                ClearDrawOrigin();
+                            }
+                        }
                     }
                 }
 
@@ -2742,6 +2769,20 @@ namespace vMenuClient
 
                             DrawTextOnScreen($"Hash {hashes}", 0f, 0f, 0.3f, Alignment.Center, 0);
                             ClearDrawOrigin();
+                        }
+                        
+                        if (MainMenu.MiscSettingsMenu.ShowEntityNetOwners && p.IsOnScreen)
+                        {
+                            int netOwnerLocalId = NetworkGetEntityOwner(p.Handle);
+
+                            if (netOwnerLocalId != 0)
+                            {
+                                int playerServerId = GetPlayerServerId(netOwnerLocalId);
+                                string playerName = GetPlayerName(netOwnerLocalId);
+                                SetDrawOrigin(p.Position.X, p.Position.Y, p.Position.Z + 0.3f, 0);
+                                DrawTextOnScreen($"Owner ID {playerServerId} ({playerName})", 0f, 0f, 0.3f, Alignment.Center, 0);
+                                ClearDrawOrigin();
+                            }
                         }
                     }
                 }

--- a/vMenu/menus/MiscSettings.cs
+++ b/vMenu/menus/MiscSettings.cs
@@ -35,6 +35,7 @@ namespace vMenuClient
         public bool ShowPropModelDimensions { get; private set; } = false;
         public bool ShowEntityHandles { get; private set; } = false;
         public bool ShowEntityModels { get; private set; } = false;
+        public bool ShowEntityNetOwners { get; private set; } = false;
         public bool MiscRespawnDefaultCharacter { get; private set; } = UserDefaults.MiscRespawnDefaultCharacter;
         public bool RestorePlayerAppearance { get; private set; } = UserDefaults.MiscRestorePlayerAppearance;
         public bool RestorePlayerWeapons { get; private set; } = UserDefaults.MiscRestorePlayerWeapons;
@@ -126,6 +127,7 @@ namespace vMenuClient
             MenuCheckboxItem pedModelDimensions = new MenuCheckboxItem("Show Ped Dimensions", "Draws the model outlines for every ped that's currently close to you.", ShowPedModelDimensions);
             MenuCheckboxItem showEntityHandles = new MenuCheckboxItem("Show Entity Handles", "Draws the the entity handles for all close entities (you must enable the outline functions above for this to work).", ShowEntityHandles);
             MenuCheckboxItem showEntityModels = new MenuCheckboxItem("Show Entity Models", "Draws the the entity models for all close entities (you must enable the outline functions above for this to work).", ShowEntityModels);
+            MenuCheckboxItem showEntityNetOwners = new MenuCheckboxItem("Show Network Owners", "Draws the the entity net owner for all close entities (you must enable the outline functions above for this to work).", ShowEntityNetOwners);
             MenuSliderItem dimensionsDistanceSlider = new MenuSliderItem("Show Dimensions Radius", "Show entity model/handle/dimension draw range.", 0, 20, 20, false);
 
             MenuItem clearArea = new MenuItem("Clear Area", "Clears the area around your player (100 meters). Damage, dirt, peds, props, vehicles, etc. Everything gets cleaned up, fixed and reset to the default world state.");
@@ -403,6 +405,7 @@ namespace vMenuClient
                 developerToolsMenu.AddMenuItem(pedModelDimensions);
                 developerToolsMenu.AddMenuItem(showEntityHandles);
                 developerToolsMenu.AddMenuItem(showEntityModels);
+                developerToolsMenu.AddMenuItem(showEntityNetOwners);
                 developerToolsMenu.AddMenuItem(dimensionsDistanceSlider);
             }
 
@@ -478,6 +481,10 @@ namespace vMenuClient
                 else if (item == showEntityModels)
                 {
                     ShowEntityModels = _checked;
+                }
+                else if (item == showEntityNetOwners)
+                {
+                    ShowEntityNetOwners = _checked;
                 }
                 else if (item == enableTimeCycle)
                 {


### PR DESCRIPTION
Added "Show Network Owners" to Developer Tools submenu. Draws server ID and player name of network owner on  closest entities just like handles and models.