### PR TITLE
Fix Broken Liveries

### DIFF
--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1796,7 +1796,7 @@ namespace vMenuClient
                     "Street"        // 11
                 };
                 MenuListItem vehicleWheelType = new MenuListItem("Wheel Type", wheelTypes, MathUtil.Clamp(GetVehicleWheelType(veh.Handle), 0, 11), $"Choose a ~y~wheel type~s~ for your vehicle.");
-                if (!veh.Model.IsBoat && !veh.Model.IsHelicopter && !veh.Model.IsPlane && !veh.Model.IsBicycle && !veh.Model.IsTrain)
+                if (!veh.Model.IsBoat && !veh.Model.IsBicycle && !veh.Model.IsTrain)
                 {
                     VehicleModMenu.AddMenuItem(vehicleWheelType);
                 }


### PR DESCRIPTION
Fix broken liveries for the akula, avenger, strikeforce, and more. 

Some vehicles seem to have the option of changing the wheels which appears to throw off the index in the mod menu and prevent the livery toggle from changing the livery.