### PR TITLE
Increase the max distance to lock personal vehicle

### DIFF
--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2847,7 +2847,7 @@ namespace vMenuClient
             {
                 if (!Game.PlayerPed.IsInVehicle(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle) && !Game.PlayerPed.IsGettingIntoAVehicle)
                 {
-                    if (Game.PlayerPed.Position.DistanceToSquared(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle.Position) < 30.0f)
+                    if (Game.PlayerPed.Position.DistanceToSquared(MainMenu.PersonalVehicleMenu.CurrentPersonalVehicle.Position) < 650.0f)
                     {
                         if (Game.IsControlJustReleased(0, Control.VehicleHorn))
                         {


### PR DESCRIPTION
Currently the max distance is 5 units in game, which seems awfully close. I have upped it in my version and feel it could be beneficial to others. I upped it to 25, which seems more realistic while not being so far that you would accidently activate it.