### PR TITLE
Updated swapped Death and Join/Leave Noti Perms

### DIFF
--- a/vMenu/menus/MiscSettings.cs
+++ b/vMenu/menus/MiscSettings.cs
@@ -537,11 +537,11 @@ namespace vMenuClient
             menu.AddMenuItem(drawTime); // always allowed
             if (IsAllowed(Permission.MSJoinQuitNotifs))
             {
-                menu.AddMenuItem(deathNotifs);
+                menu.AddMenuItem(joinQuitNotifs);
             }
             if (IsAllowed(Permission.MSDeathNotifs))
             {
-                menu.AddMenuItem(joinQuitNotifs);
+                menu.AddMenuItem(deathNotifs);
             }
             if (IsAllowed(Permission.MSNightVision))
             {


### PR DESCRIPTION
The permissions for Death Notifications and Join/Leave Notifications are swapped around, this resolves the issue.