### PR TITLE
Disable Avoiding Death Glitch

### DIFF
--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -130,7 +130,15 @@ namespace vMenuClient
             {
                 if (item == spawnSavedPed)
                 {
-                    await SetPlayerSkin(savedPed.Value.model, savedPed.Value, true);
+                    int theplayerped = PlayerPedId();
+                    if (IsPedInAnyVehicle(theplayerped, true) || IsEntityInAir(theplayerped) || IsPedFalling(theplayerped))
+                    {
+                        Notify.Error("~w~You are not allowed to spawn ped right now! - ~y~Petris");
+                    }
+                    else
+                    {
+                        await SetPlayerSkin(savedPed.Value.model, savedPed.Value, true);
+                    }
                 }
                 else if (item == cloneSavedPed)
                 {


### PR DESCRIPTION
I disabled spawning a ped from Player Appearance and MP Ped Customization while the player is in air, falling or in a vehicle that has as target to make players cannot avoid their fall damage death!