### PR TITLE
fix: remove invalid function

### DIFF
--- a/vMenu/menus/PersonalVehicle.cs
+++ b/vMenu/menus/PersonalVehicle.cs
@@ -192,12 +192,10 @@ namespace vMenuClient
                         {
                             if (_checked)
                             {
-                                SetVehicleExclusiveDriver(CurrentPersonalVehicle.Handle, Game.PlayerPed.Handle, 1);
                                 SetVehicleExclusiveDriver_2(CurrentPersonalVehicle.Handle, Game.PlayerPed.Handle, 1);
                             }
                             else
                             {
-                                SetVehicleExclusiveDriver(CurrentPersonalVehicle.Handle, 0, 1);
                                 SetVehicleExclusiveDriver_2(CurrentPersonalVehicle.Handle, 0, 1);
                             }
                         }


### PR DESCRIPTION
This change removes a `API` function call that would invalidate the entire delegate function. The function in question had parameters changed in a [recent update](https://github.com/citizenfx/natives/blame/master/VEHICLE/SetVehicleExclusiveDriver.md), which caused an exception to be thrown when `OnCheckboxChanged` was called from MenuAPI.

**Exception Log**

```
[    142250] [b2189_GTAProce]             MainThrd/ Failed to run a tick for MenuController: System.BadImageFormatException: Error verifying vMenuClient.PersonalVehicle/<>c__DisplayClass14_0:<CreateMenu>b__1 (MenuAPI.Menu,MenuAPI.MenuCheckboxItem,int,bool): Cannot load method from token 0x0a000528 for call at 0x01b6
[    142250] [b2189_GTAProce]             MainThrd/   at MenuAPI.Menu.CheckboxChangedEvent (MenuAPI.MenuCheckboxItem menuItem, System.Int32 itemIndex, System.Boolean _checked) [0x00001] in C:\projects\menuapi\MenuAPI\Menu.cs:205 
[    142250] [b2189_GTAProce]             MainThrd/   at MenuAPI.Menu.SelectItem (MenuAPI.MenuItem item) [0x00035] in C:\projects\menuapi\MenuAPI\Menu.cs:776 
[    142250] [b2189_GTAProce]             MainThrd/   at MenuAPI.Menu.SelectItem (System.Int32 index) [0x0002e] in C:\projects\menuapi\MenuAPI\Menu.cs:753 
[    142250] [b2189_GTAProce]             MainThrd/   at MenuAPI.MenuController+<ProcessMainButtons>d__77.MoveNext () [0x000dd] in C:\projects\menuapi\MenuAPI\MenuController.cs:332 
```