### PR TITLE
Fix faraway spectate teleporting/GPS routes

### DIFF
--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -2216,7 +2216,7 @@ namespace vMenuClient
                             }
                             else // blips are not enabled.
                             {
-                                if (!(p.Character.AttachedBlip == null || !p.Character.AttachedBlip.Exists()) && MainMenu.OnlinePlayersMenu != null && !MainMenu.OnlinePlayersMenu.PlayersWaypointList.Contains(p.Handle))
+                                if (!(p.Character.AttachedBlip == null || !p.Character.AttachedBlip.Exists()) && MainMenu.OnlinePlayersMenu != null && !MainMenu.OnlinePlayersMenu.PlayersWaypointList.Contains(p.ServerId))
                                 {
                                     p.Character.AttachedBlip.Delete(); // remove player blip if it exists.
                                 }
@@ -2329,14 +2329,17 @@ namespace vMenuClient
             await Delay(500);
             if (MainMenu.OnlinePlayersMenu.PlayersWaypointList.Count > 0)
             {
-                foreach (int playerId in MainMenu.OnlinePlayersMenu.PlayersWaypointList)
+                foreach (int serverId in MainMenu.OnlinePlayersMenu.PlayersWaypointList)
                 {
-                    if (!NetworkIsPlayerActive(playerId))
+                    var player = MainMenu.PlayersList.FirstOrDefault(a => a.ServerId == serverId);
+
+                    if (player == null)
                     {
-                        waypointPlayerIdsToRemove.Add(playerId);
+                        waypointPlayerIdsToRemove.Add(serverId);
                     }
-                    else
+                    else if (player.Character != null)
                     {
+                        var playerId = player.Handle;
                         Vector3 pos1 = GetEntityCoords(GetPlayerPed(playerId), true);
                         Vector3 pos2 = Game.PlayerPed.Position;
                         if (Vdist2(pos1.X, pos1.Y, pos1.Z, pos2.X, pos2.Y, pos2.Z) < 20f)
@@ -2357,6 +2360,15 @@ namespace vMenuClient
                 {
                     foreach (int id in waypointPlayerIdsToRemove)
                     {
+                        if (MainMenu.OnlinePlayersMenu.PlayerCoordWaypoints.TryGetValue(id, out var blip))
+                        {
+                            if (DoesBlipExist(blip))
+                            {
+                                SetBlipRoute(blip, false);
+                                RemoveBlip(ref blip);
+                            }
+                        }
+
                         MainMenu.OnlinePlayersMenu.PlayersWaypointList.Remove(id);
                     }
                     await Delay(10);


### PR DESCRIPTION
This uses the suggested method for setting camera while faded out to allow spectating faraway players without actually teleporting.

Also, there's support for 'fake' single-update GPS route blips (though removing when nearby may not work yet, needs more testing) for faraway players instead of the broken behavior before.