### PR TITLE
Add Event Trigger for Infinite Fuel Toggle

### DIFF
--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -1368,7 +1368,7 @@ namespace vMenuClient
             }
 
             // Enable/disable infinite ammo.
-            if (IsAllowed(Permission.WPUnlimitedAmmo) && Game.PlayerPed.Weapons.Current != null && Game.PlayerPed.Weapons.Current.Hash != WeaponHash.Unarmed)
+            if (Game.PlayerPed.Weapons.Current != null && Game.PlayerPed.Weapons.Current.Hash != WeaponHash.Unarmed && IsAllowed(Permission.WPUnlimitedAmmo))
             {
                 Game.PlayerPed.Weapons.Current.InfiniteAmmo = MainMenu.WeaponOptionsMenu.UnlimitedAmmo;
             }

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -1368,7 +1368,7 @@ namespace vMenuClient
             }
 
             // Enable/disable infinite ammo.
-            if (Game.PlayerPed.Weapons.Current != null && Game.PlayerPed.Weapons.Current.Hash != WeaponHash.Unarmed && IsAllowed(Permission.WPUnlimitedAmmo))
+            if (IsAllowed(Permission.WPUnlimitedAmmo) && Game.PlayerPed.Weapons.Current != null && Game.PlayerPed.Weapons.Current.Hash != WeaponHash.Unarmed)
             {
                 Game.PlayerPed.Weapons.Current.InfiniteAmmo = MainMenu.WeaponOptionsMenu.UnlimitedAmmo;
             }

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -644,6 +644,7 @@ namespace vMenuClient
                 else if (item == infiniteFuel)
                 {
                     VehicleInfiniteFuel = _checked;
+                    TriggerEvent("vMenu:InfiniteFuelToggled", _checked);
                 }
             };
             #endregion


### PR DESCRIPTION
Allows custom fuel resources to watch for infinite fuel in vMenu within other client-sided scripts.

Event name: "vMenu:InfiniteFuelToggled"
Passes one arg, the boolean representing whether the box is checked or not