### PR TITLE
Change InfiniteAmmo only if WPUnlimitedAmmo is allowed

### DIFF
--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -1382,9 +1382,9 @@ namespace vMenuClient
             }
 
             // Enable/disable infinite ammo.
-            if (Game.PlayerPed.Weapons.Current != null && Game.PlayerPed.Weapons.Current.Hash != WeaponHash.Unarmed)
+            if (Game.PlayerPed.Weapons.Current != null && Game.PlayerPed.Weapons.Current.Hash != WeaponHash.Unarmed && IsAllowed(Permission.WPUnlimitedAmmo))
             {
-                Game.PlayerPed.Weapons.Current.InfiniteAmmo = MainMenu.WeaponOptionsMenu.UnlimitedAmmo && IsAllowed(Permission.WPUnlimitedAmmo);
+                Game.PlayerPed.Weapons.Current.InfiniteAmmo = MainMenu.WeaponOptionsMenu.UnlimitedAmmo;
             }
 
             if (MainMenu.WeaponOptionsMenu.AutoEquipChute)

--- a/vMenu/FunctionsController.cs
+++ b/vMenu/FunctionsController.cs
@@ -1382,7 +1382,7 @@ namespace vMenuClient
             }
 
             // Enable/disable infinite ammo.
-            if (Game.PlayerPed.Weapons.Current != null && Game.PlayerPed.Weapons.Current.Hash != WeaponHash.Unarmed && IsAllowed(Permission.WPUnlimitedAmmo))
+            if (IsAllowed(Permission.WPUnlimitedAmmo) && Game.PlayerPed.Weapons.Current != null && Game.PlayerPed.Weapons.Current.Hash != WeaponHash.Unarmed)
             {
                 Game.PlayerPed.Weapons.Current.InfiniteAmmo = MainMenu.WeaponOptionsMenu.UnlimitedAmmo;
             }


### PR DESCRIPTION
At the moment, if the weapons menu is enabled, vMenu modifies `Game.PlayerPed.Weapons.Current.InfiniteAmmo` on each tick. However, this breaks any other scripts that touch that property.

This changes the handler so that infinite ammo is set at all only if `vMenu.WeaponOptions.UnlimitedAmmo` as a permission is enabled, so at least it could be fixed by disabling that permission, while keeping the rest of the menu enabled.