### PR TITLE
Chameleon Paint Job Update

### DIFF
--- a/SharedClasses/ConfigManager.cs
+++ b/SharedClasses/ConfigManager.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using CitizenFX.Core;
-
-using Newtonsoft.Json;
-
 using static CitizenFX.Core.Native.API;
+using Newtonsoft.Json;
 
 namespace vMenuShared
 {
@@ -33,13 +33,16 @@ namespace vMenuShared
             vmenu_disable_entity_outlines_tool,
             vmenu_disable_player_stats_setup,
 
+            // Vehicle Chameleon Colours
+            vmenu_using_chameleon_colours,
+
             // Kick & ban settings
             vmenu_default_ban_message_information,
             vmenu_auto_ban_cheaters,
             vmenu_auto_ban_cheaters_ban_message,
             vmenu_log_ban_actions,
             vmenu_log_kick_actions,
-
+            
             // Weather settings
             vmenu_enable_weather_sync,
             vmenu_enable_dynamic_weather,
@@ -136,15 +139,6 @@ namespace vMenuShared
         public static bool IsClientDebugModeEnabled()
         {
             return GetResourceMetadata("vMenu", "client_debug_mode", 0).ToLower() == "true";
-        }
-        
-        /// <summary>
-        /// Default value for server-side chameleon colours.
-        /// </summary>
-        /// <returns></returns>
-        public static bool IsServerUsingChameleonColours()
-        {
-            return GetConvar("server_using_chameleon_colours", "false");
         }
 
         #region Get saved locations from the locations.json

--- a/SharedClasses/ConfigManager.cs
+++ b/SharedClasses/ConfigManager.cs
@@ -144,7 +144,7 @@ namespace vMenuShared
         /// <returns></returns>
         public static bool IsServerUsingChameleonColours()
         {
-            return GetResourceMetadata("vMenu", "server_using_chameleon_colours", 0).ToLower() == "true";
+            return GetConvar("server_using_chameleon_colours", "false");
         }
 
         #region Get saved locations from the locations.json

--- a/SharedClasses/ConfigManager.cs
+++ b/SharedClasses/ConfigManager.cs
@@ -137,6 +137,15 @@ namespace vMenuShared
         {
             return GetResourceMetadata("vMenu", "client_debug_mode", 0).ToLower() == "true";
         }
+        
+        /// <summary>
+        /// Default value for server-side chameleon colours.
+        /// </summary>
+        /// <returns></returns>
+        public static bool IsServerUsingChameleonColours()
+        {
+            return GetResourceMetadata("vMenu", "server_using_chameleon_colours", 0).ToLower() == "true";
+        }
 
         #region Get saved locations from the locations.json
         /// <summary>

--- a/vMenu/data/VehicleData.cs
+++ b/vMenu/data/VehicleData.cs
@@ -38,6 +38,71 @@ namespace vMenuClient
                         CitizenFX.Core.Native.API.AddTextEntry("VERY_DARK_BLUE", "Very Dark Blue");
                     }
                 }
+                // Chameleon Colour Labels //
+                else if (label == "G9_PAINT01")
+                {
+                    AddTextEntry("G9_PAINT01", "Monochrome");
+                }
+                else if (label == "G9_PAINT02")
+                {
+                    AddTextEntry("G9_PAINT02", "Night & Day");
+                }
+                else if (label == "G9_PAINT03")
+                {
+                    AddTextEntry("G9_PAINT03", "The Verlierer");
+                }
+                else if (label == "G9_PAINT04")
+                {
+                    AddTextEntry("G9_PAINT04", "Sprunk Extreme");
+                }
+                else if (label == "G9_PAINT05")
+                {
+                    AddTextEntry("G9_PAINT05", "Vice City");
+                }
+                else if (label == "G9_PAINT06")
+                {
+                    AddTextEntry("G9_PAINT06", "Synthwave Nights");
+                }
+                else if (label == "G9_PAINT07")
+                {
+                    AddTextEntry("G9_PAINT07", "Four Seasons");
+                }
+                else if (label == "G9_PAINT08")
+                {
+                    AddTextEntry("G9_PAINT08", "Maisonette 9 Throwback");
+                }
+                else if (label == "G9_PAINT09")
+                {
+                    AddTextEntry("G9_PAINT09", "Bubblegum");
+                }
+                else if (label == "G9_PAINT10")
+                {
+                    AddTextEntry("G9_PAINT10", "Full Rainbow");
+                }
+                else if (label == "G9_PAINT11")
+                {
+                    AddTextEntry("G9_PAINT11", "Sunset");
+                }
+                else if (label == "G9_PAINT12")
+                {
+                    AddTextEntry("G9_PAINT12", "The Seven");
+                }
+                else if (label == "G9_PAINT13")
+                {
+                    AddTextEntry("G9_PAINT13", "Kamen Rider");
+                }
+                else if (label == "G9_PAINT14")
+                {
+                    AddTextEntry("G9_PAINT14", "Chromatic Aberration");
+                }
+                else if (label == "G9_PAINT15")
+                {
+                    AddTextEntry("G9_PAINT15", "It's Christmas!");
+                }
+                else if (label == "G9_PAINT16")
+                {
+                    AddTextEntry("G9_PAINT16", "Temperature");
+                }
 
                 this.label = label;
                 this.id = id;
@@ -259,6 +324,27 @@ namespace vMenuClient
             new VehicleColor(131, "WHITE"),
             new VehicleColor(132, "FROST_WHITE"),
             new VehicleColor(133, "OLIVE_GREEN"),
+        };
+        
+        // Chameleon Colour List //
+        public static readonly List<VehicleColor> ChameleonColors = new List<VehicleColor>()
+        {
+            new VehicleColor(223, "G9_PAINT01"),
+            new VehicleColor(224, "G9_PAINT02"),
+            new VehicleColor(225, "G9_PAINT03"),
+            new VehicleColor(226, "G9_PAINT04"),
+            new VehicleColor(227, "G9_PAINT05"),
+            new VehicleColor(228, "G9_PAINT06"),
+            new VehicleColor(229, "G9_PAINT07"),
+            new VehicleColor(230, "G9_PAINT08"),
+            new VehicleColor(231, "G9_PAINT09"),
+            new VehicleColor(232, "G9_PAINT10"),
+            new VehicleColor(233, "G9_PAINT11"),
+            new VehicleColor(234, "G9_PAINT12"),
+            new VehicleColor(235, "G9_PAINT13"),
+            new VehicleColor(236, "G9_PAINT14"),
+            new VehicleColor(237, "G9_PAINT15"),
+            new VehicleColor(238, "G9_PAINT16"),
         };
 
         public static class Vehicles

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -10,6 +10,7 @@ using static CitizenFX.Core.UI.Screen;
 using static CitizenFX.Core.Native.API;
 using static vMenuClient.CommonFunctions;
 using static vMenuShared.PermissionsManager;
+using static vMenuShared.ConfigManager;
 
 namespace vMenuClient
 {
@@ -964,6 +965,7 @@ namespace vMenuClient
             List<string> metals = new List<string>();
             List<string> util = new List<string>();
             List<string> worn = new List<string>();
+            List<string> chameleon = new List<string>();
             List<string> wheelColors = new List<string>() { "Default Alloy" };
 
             // Just quick and dirty solution to put this in a new enclosed section so that we can still use 'i' as a counter in the other code parts.
@@ -1001,6 +1003,15 @@ namespace vMenuClient
                 {
                     worn.Add($"{GetLabelText(vc.label)} ({i + 1}/{VehicleData.WornColors.Count})");
                     i++;
+                }
+                
+                if (IsServerUsingChameleonColours()) {
+                    i = 0;
+                    foreach (var vc in VehicleData.ChameleonColors)
+                    {
+                        chameleon.Add($"{GetLabelText(vc.label)} ({i + 1}/{VehicleData.ChameleonColors.Count})");
+                        i++;
+                    }
                 }
 
                 wheelColors.AddRange(classic);
@@ -1095,6 +1106,16 @@ namespace vMenuClient
                                 primaryColor = VehicleData.WornColors[newIndex].id;
                                 break;
                         }
+                        
+                        if (IsServerUsingChameleonColours()) {
+                            if (itemIndex == 6) {
+                                primaryColor = VehicleData.ChameleonColors[newIndex].id;
+                                secondaryColor = VehicleData.ChameleonColors[newIndex].id;
+                                
+                                SetVehicleModKit(veh.Handle, 0);
+                            }
+                        }
+                        
                         SetVehicleColours(veh.Handle, primaryColor, secondaryColor);
                     }
                     else if (sender == secondaryColorsMenu)
@@ -1178,6 +1199,11 @@ namespace vMenuClient
                     primaryColorsMenu.AddMenuItem(metalList);
                     primaryColorsMenu.AddMenuItem(utilList);
                     primaryColorsMenu.AddMenuItem(wornList);
+                    if (IsServerUsingChameleonColours()) {
+                        var chameleonList = new MenuListItem("Chameleon", chameleon, 0);
+
+                        primaryColorsMenu.AddMenuItem(chameleonList);
+                    }
 
                     primaryColorsMenu.OnListIndexChange += HandleListIndexChanges;
                 }

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -151,12 +151,10 @@ namespace vMenuClient
                 radioIndex = index;
             }
 
-            MenuListItem radioStations = new MenuListItem("Default radio station", stationNames, radioIndex, "Select a default radio station to be set when spawning new car");
+            MenuListItem radioStations = new MenuListItem("Default radio station", stationNames, radioIndex, "Select a defalut radio station to be set when spawning new car");
 
             var tiresList = new List<string>() { "All Tires", "Tire #1", "Tire #2", "Tire #3", "Tire #4", "Tire #5", "Tire #6", "Tire #7", "Tire #8" };
             MenuListItem vehicleTiresList = new MenuListItem("Fix / Destroy Tires", tiresList, 0, "Fix or destroy a specific vehicle tire, or all of them at once. Note, not all indexes are valid for all vehicles, some might not do anything on certain vehicles.");
-
-            MenuItem destroyEngine = new MenuItem("Destroy Engine", "Destroys your vehicle's engine.");
 
             MenuItem deleteBtn = new MenuItem("~r~Delete Vehicle", "Delete your vehicle, this ~r~can NOT be undone~s~!")
             {
@@ -371,10 +369,6 @@ namespace vMenuClient
                 menu.AddMenuItem(vehicleTiresList);
                 //menu.AddMenuItem(destroyTireList);
             }
-            if (IsAllowed(Permission.VODestroyEngine)) // DESTROY VEHICLE ENGINE
-            {
-                menu.AddMenuItem(destroyEngine);
-            }
             if (IsAllowed(Permission.VOFreeze)) // FREEZE VEHICLE
             {
                 menu.AddMenuItem(vehicleFreeze);
@@ -509,8 +503,7 @@ namespace vMenuClient
                         {
                             SetLicensePlateCustomText();
                         }
-                        // Make vehicle invisible.
-                        else if (item == vehicleInvisible) 
+                        else if (item == vehicleInvisible) // Make vehicle invisible.
                         {
                             if (vehicle.IsVisible)
                             {
@@ -535,11 +528,6 @@ namespace vMenuClient
                                 // Set the vehicle invisible or invincivble.
                                 vehicle.IsVisible = !vehicle.IsVisible;
                             }
-                        }
-                        // Destroy vehicle engine
-                        else if (item == destroyEngine)
-                        {
-                            SetVehicleEngineHealth(vehicle.Handle, -4000);
                         }
                     }
 
@@ -1004,8 +992,9 @@ namespace vMenuClient
                     worn.Add($"{GetLabelText(vc.label)} ({i + 1}/{VehicleData.WornColors.Count})");
                     i++;
                 }
-                
-                if (IsServerUsingChameleonColours()) {
+
+                if (GetSettingsBool(Setting.vmenu_using_chameleon_colours))
+                {
                     i = 0;
                     foreach (var vc in VehicleData.ChameleonColors)
                     {
@@ -1106,16 +1095,18 @@ namespace vMenuClient
                                 primaryColor = VehicleData.WornColors[newIndex].id;
                                 break;
                         }
-                        
-                        if (IsServerUsingChameleonColours()) {
-                            if (itemIndex == 6) {
+
+                        if (GetSettingsBool(Setting.vmenu_using_chameleon_colours))
+                        {
+                            if (itemIndex == 6)
+                            {
                                 primaryColor = VehicleData.ChameleonColors[newIndex].id;
                                 secondaryColor = VehicleData.ChameleonColors[newIndex].id;
-                                
+
                                 SetVehicleModKit(veh.Handle, 0);
                             }
                         }
-                        
+
                         SetVehicleColours(veh.Handle, primaryColor, secondaryColor);
                     }
                     else if (sender == secondaryColorsMenu)
@@ -1199,7 +1190,9 @@ namespace vMenuClient
                     primaryColorsMenu.AddMenuItem(metalList);
                     primaryColorsMenu.AddMenuItem(utilList);
                     primaryColorsMenu.AddMenuItem(wornList);
-                    if (IsServerUsingChameleonColours()) {
+
+                    if (GetSettingsBool(Setting.vmenu_using_chameleon_colours))
+                    {
                         var chameleonList = new MenuListItem("Chameleon", chameleon, 0);
 
                         primaryColorsMenu.AddMenuItem(chameleonList);
@@ -1836,10 +1829,9 @@ namespace vMenuClient
                     "Benny's (1)",  // 8
                     "Benny's (2)",  // 9
                     "Open Wheel",   // 10
-                    "Street",       // 11
-                    "Track"         // 12
+                    "Street"        // 11
                 };
-                MenuListItem vehicleWheelType = new MenuListItem("Wheel Type", wheelTypes, MathUtil.Clamp(GetVehicleWheelType(veh.Handle), 0, 12), $"Choose a ~y~wheel type~s~ for your vehicle.");
+                MenuListItem vehicleWheelType = new MenuListItem("Wheel Type", wheelTypes, MathUtil.Clamp(GetVehicleWheelType(veh.Handle), 0, 11), $"Choose a ~y~wheel type~s~ for your vehicle.");
                 if (!veh.Model.IsBoat && !veh.Model.IsHelicopter && !veh.Model.IsPlane && !veh.Model.IsBicycle && !veh.Model.IsTrain)
                 {
                     VehicleModMenu.AddMenuItem(vehicleWheelType);
@@ -1850,7 +1842,6 @@ namespace vMenuClient
                 MenuCheckboxItem xenonHeadlights = new MenuCheckboxItem("Xenon Headlights", "Enable or disable ~b~xenon ~s~headlights.", IsToggleModOn(veh.Handle, 22));
                 MenuCheckboxItem turbo = new MenuCheckboxItem("Turbo", "Enable or disable the ~y~turbo~s~ for this vehicle.", IsToggleModOn(veh.Handle, 18));
                 MenuCheckboxItem bulletProofTires = new MenuCheckboxItem("Bullet Proof Tires", "Enable or disable ~y~bullet proof tires~s~ for this vehicle.", !GetVehicleTyresCanBurst(veh.Handle));
-                MenuCheckboxItem lowGripTires = new MenuCheckboxItem("Low Grip Tires", "Enable or disable ~y~low grip tires~s~ for this vehicle.", GetDriftTyresEnabled(veh.Handle));
 
                 // Add the checkboxes to the menu.
                 VehicleModMenu.AddMenuItem(toggleCustomWheels);
@@ -1864,7 +1855,6 @@ namespace vMenuClient
                 VehicleModMenu.AddMenuItem(headlightColor);
                 VehicleModMenu.AddMenuItem(turbo);
                 VehicleModMenu.AddMenuItem(bulletProofTires);
-                VehicleModMenu.AddMenuItem(lowGripTires);
                 // Create a list of tire smoke options.
                 List<string> tireSmokes = new List<string>() { "Red", "Orange", "Yellow", "Gold", "Light Green", "Dark Green", "Light Blue", "Dark Blue", "Purple", "Pink", "Black" };
                 Dictionary<string, int[]> tireSmokeColors = new Dictionary<string, int[]>()
@@ -1958,11 +1948,6 @@ namespace vMenuClient
                     else if (item2 == bulletProofTires)
                     {
                         SetVehicleTyresCanBurst(veh.Handle, !_checked);
-                    }
-                    // Low Grip Tyres
-                    else if (item2 == lowGripTires)
-                    {
-                        SetDriftTyresEnabled(veh.Handle, _checked);
                     }
                     // Custom Wheels
                     else if (item2 == toggleCustomWheels)

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -123,6 +123,11 @@ setr vmenu_current_minute 0
 # Enabling this will prevent you from setting a custom time, freezing the time and changing the time duration.
 setr vmenu_sync_to_machine_time false
 
+### Vehicle options ###
+# Setting this to true will enable the chameleon colour vehicle paints category in the primary colours menu.
+# You must be streaming the chameleon colours in order for this to function properly.
+setr server_using_chameleon_colours false
+
 
 #############################################################################################
 #                                    vMenu PERMISSIONS                                      #

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -126,7 +126,7 @@ setr vmenu_sync_to_machine_time false
 ### Vehicle options ###
 # Setting this to true will enable the chameleon colour vehicle paints category in the primary colours menu.
 # You must be streaming the chameleon colours in order for this to function properly.
-setr server_using_chameleon_colours false
+setr vmenu_using_chameleon_colours false
 
 
 #############################################################################################


### PR DESCRIPTION
Added a list item to the Primary Colours menu of vMenu that allows players to set their vehicle colours with the new chameleon colour ramps from Expanded & Enhanced.

For this to work, You will need to be streaming the custom Chameleon Colours mod on FiveM.

You can change `setr vmenu_using_chameleon_colours false` to `setr vmenu_using_chameleon_colours true` in the permissions.cfg to enable this colour category in primary colours.

If you wish to use these amazing vehicle colours. Please read through these links:
Chameleon Colours (GTA 5 Mod) - https://gta5-mods.com/misc/chameleon-paint-add-on
Streaming these paints in FiveM - https://forum.cfx.re/t/how-to-get-the-chameleon-paints/4869883