### PR TITLE
Fixed NewLoadSceneStart not being stopped in the teleporting method

### DIFF
--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -577,7 +577,7 @@ namespace vMenuClient
                     tempTimer = GetGameTimer();
 
                     // Wait for the scene to be loaded with a timeout.
-                    while (!IsNewLoadSceneLoaded() && Game.GameTime - tempTimer < 10000) // Can take up to 10 seconds
+                    while (!IsNewLoadSceneLoaded() && Game.GameTime - tempTimer < 3000)
                     {
                         await BaseScript.Delay(0);
                     }

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -567,6 +567,27 @@ namespace vMenuClient
                     // it seem to load the world ANY faster than without, but whatever.
                     RequestCollisionAtCoord(pos.X, pos.Y, z);
 
+                    // Set focus for that area.
+                    SetFocusPosAndVel(pos.X, pos.Y, pos.Z, 0, 0, 0);
+
+                    // Start to load the scene.
+                    NewLoadSceneStart(pos.X, pos.Y, pos.Z, pos.X, pos.Y, pos.Z, 50f, 0);
+
+                    // Reset the timer.
+                    tempTimer = GetGameTimer();
+
+                    // Wait for the scene to be loaded with a timeout.
+                    while (!IsNewLoadSceneLoaded() && Game.GameTime - tempTimer < 10000) // Can take up to 10 seconds
+                    {
+                        await BaseScript.Delay(0);
+                    }
+
+                    // Clear the focus for that area.
+                    ClearFocus();
+
+                    // Important! This step was missing before, not setting this would cause areas outside the scene to become unrendered aka "city mud" would appear.
+                    NewLoadSceneStop();
+
                     // If the player is in a vehicle, teleport the vehicle to this new position.
                     if (inVehicle())
                     {
@@ -666,27 +687,6 @@ namespace vMenuClient
                     }
                     Game.PlayerPed.IsPositionFrozen = false;
                 }
-
-                // Set focus for that area.
-                SetFocusPosAndVel(pos.X, pos.Y, pos.Z, 0, 0, 0);
-
-                // Start to load the scene.
-                NewLoadSceneStart(pos.X, pos.Y, pos.Z, pos.X, pos.Y, pos.Z, 50f, 0);
-
-                // Reset the timer.
-                tempTimer = GetGameTimer();
-
-                // Wait for the scene to be loaded with a timeout.
-                while (!IsNewLoadSceneLoaded() && Game.GameTime - tempTimer < 10000) // Can take up to 10 seconds
-                {
-                    await BaseScript.Delay(0);
-                }
-
-                // Clear the focus for that area.
-                ClearFocus();
-
-                // Important! This step was missing before, not setting this would cause areas outside the scene to become unrendered aka "city mud" would appear.
-                NewLoadSceneStop();
 
                 // Fade screen in and reset the camera angle.
                 DoScreenFadeIn(500);

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -540,6 +540,9 @@ namespace vMenuClient
                     await Delay(0);
                 }
 
+                // Timer to make sure things don't get out of hand (player having to wait forever to get teleported if something fails).
+                int tempTimer;
+
                 // This will be used to get the return value from the groundz native.
                 float groundZ = 850.0f;
 
@@ -563,25 +566,6 @@ namespace vMenuClient
                     // It doesn't matter to get the ground z coord, and neither does it actually prevent entities from falling through the map, nor does
                     // it seem to load the world ANY faster than without, but whatever.
                     RequestCollisionAtCoord(pos.X, pos.Y, z);
-
-                    // Request a new scene. This will trigger the world to be loaded around that area.
-                    NewLoadSceneStart(pos.X, pos.Y, z, pos.X, pos.Y, z, 50f, 0);
-
-                    // Timer to make sure things don't get out of hand (player having to wait forever to get teleported if something fails).
-                    int tempTimer = GetGameTimer();
-
-                    // Wait for the new scene to be loaded.
-                    while (IsNetworkLoadingScene())
-                    {
-                        // If this takes longer than 1 second, just abort. It's not worth waiting that long.
-                        if (GetGameTimer() - tempTimer > 1000)
-                        {
-                            Log("Waiting for the scene to load is taking too long (more than 1s). Breaking from wait loop.");
-                            break;
-                        }
-
-                        await Delay(0);
-                    }
 
                     // If the player is in a vehicle, teleport the vehicle to this new position.
                     if (inVehicle())
@@ -682,6 +666,27 @@ namespace vMenuClient
                     }
                     Game.PlayerPed.IsPositionFrozen = false;
                 }
+
+                // Set focus for that area.
+                SetFocusPosAndVel(pos.X, pos.Y, pos.Z, 0, 0, 0);
+
+                // Start to load the scene.
+                NewLoadSceneStart(pos.X, pos.Y, pos.Z, pos.X, pos.Y, pos.Z, 50f, 0);
+
+                // Reset the timer.
+                tempTimer = GetGameTimer();
+
+                // Wait for the scene to be loaded with a timeout.
+                while (!IsNewLoadSceneLoaded() && Game.GameTime - tempTimer < 10000) // Can take up to 10 seconds
+                {
+                    await BaseScript.Delay(0);
+                }
+
+                // Clear the focus for that area.
+                ClearFocus();
+
+                // Important! This step was missing before, not setting this would cause areas outside the scene to become unrendered aka "city mud" would appear.
+                NewLoadSceneStop();
 
                 // Fade screen in and reset the camera angle.
                 DoScreenFadeIn(500);


### PR DESCRIPTION
This was causing texture loss in the city when using the teleport to waypoint option or teleport to player option (which both were using the safe teleport option).

**NewLoadSceneStart not stopped**
https://user-images.githubusercontent.com/46331538/222713050-8df048a0-aca8-4440-bc81-9114ea648a2b.mp4

**NewLoadSceneStart stopped**
https://user-images.githubusercontent.com/46331538/222713339-d07a244a-439d-4b7c-926b-247982a7aa23.mp4

