### PR TITLE
Update EventManager.cs 

### DIFF
--- a/vMenu/EventManager.cs
+++ b/vMenu/EventManager.cs
@@ -232,6 +232,7 @@ namespace vMenuClient
         {
             await UpdateWeatherParticles();
             SetArtificialLightsState(IsBlackoutEnabled);
+            SetArtificialLightsStateAffectsVehicles(false); 
             if (GetNextWeatherType() != GetHashKey(GetServerWeather))
             {
                 SetWeatherTypeOvertimePersist(GetServerWeather, (float)WeatherChangeTime);


### PR DESCRIPTION
Allows the use of headlights on vehicles while the blackout is enabled, as shown with image 
![image](https://github.com/TomGrobbe/vMenu/assets/158235157/a0f73baf-55e1-4650-9626-c24bf1c8d968)
