### PR TITLE
Add a toggle resource export

### DIFF
--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -325,6 +325,8 @@ namespace vMenuClient
                 }
             }), false);
 
+            this.Exports.Add("ToggleResource", new Action<bool>(this.ToggleResource));
+
             if (GetCurrentResourceName() != "vMenu")
             {
                 MenuController.MainMenu = null;
@@ -900,5 +902,19 @@ namespace vMenuClient
             }
         }
         #endregion
+
+        private void ToggleResource(bool toggle)
+        {
+            if (!toggle)
+            {
+                MenuController.DontOpenAnyMenu = true;
+                MenuController.DisableMenuButtons = true;
+            }
+            else
+            {
+                MenuController.DontOpenAnyMenu = false;
+                MenuController.DisableMenuButtons = false;
+            }
+        }
     }
 }


### PR DESCRIPTION
This allows server owners/developers to disable the entire resource via a client export. This is useful for soft whitelist and penalization scripts. This is a very rare use case but useful for some servers