### PR TITLE
Add Weapon Options Menu to Addon Weapons Menu

### DIFF
--- a/vMenu/data/ValidAddonWeapon.cs
+++ b/vMenu/data/ValidAddonWeapon.cs
@@ -1,0 +1,124 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using CitizenFX.Core;
+
+using Newtonsoft.Json;
+
+using static CitizenFX.Core.Native.API;
+using static vMenuClient.CommonFunctions;
+using static vMenuShared.PermissionsManager;
+
+namespace vMenuClient.data
+{
+    public struct ValidAddonWeapon
+    {
+        public uint Hash;
+        public string Name;
+        public Dictionary<string, uint> AddonComponents;
+        public Permission Perm;
+        public string SpawnName;
+        public readonly int GetMaxAmmo
+        {
+            get
+            {
+                var ammo = 0; GetMaxAmmo(Game.PlayerPed.Handle, Hash, ref ammo); return ammo;
+            }
+        }
+        public int CurrentAmmo;
+        public int CurrentTint;
+        public readonly float Accuracy
+        {
+            get
+            {
+                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudAccuracy;
+            }
+        }
+        public readonly float Damage
+        {
+            get
+            {
+                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudDamage;
+            }
+        }
+        public readonly float Range
+        {
+            get
+            {
+                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudRange;
+            }
+        }
+        public readonly float Speed
+        {
+            get
+            {
+                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudSpeed;
+            }
+        }
+    }
+
+    public static class ValidAddonWeapons
+    {
+        private static readonly List<ValidAddonWeapon> _addonWeaponsList = new();
+
+        public static List<ValidAddonWeapon> AddonWeaponsList
+        {
+            get
+            {
+                var addons = LoadResourceFile(GetCurrentResourceName(), "config/addons.json") ?? "{}";
+                var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
+                if (_addonWeaponsList.Count == addonsFile["weapons"].Count - 1)
+                {
+                    return _addonWeaponsList;
+                }
+                CreateAddonWeaponsList();
+                return _addonWeaponsList;
+            }
+        }
+
+        private static void CreateAddonWeaponsList()
+        {
+            _addonWeaponsList.Clear();
+            var addons = LoadResourceFile(GetCurrentResourceName(), "config/addons.json") ?? "{}";
+            var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
+            if (addonsFile.ContainsKey("weapons"))
+            {
+                var keyValuePairs = addonsFile["weapons"]
+                    .ToDictionary(key => key, key => GetLabelText(key));
+                foreach (var addonWeapon in keyValuePairs)
+                {
+                    var realName = addonWeapon.Key;
+                    var localizedName = addonWeapon.Value;
+                    if (realName == "weapon_unarmed") continue;
+                    var hash = (uint)GetHashKey(realName);
+                    var componentHashes = new Dictionary<string, uint>();
+                    var weaponComponents = ValidWeapons.GetWeaponComponents();
+                    foreach (var comp in weaponComponents.Keys)
+                    {
+                        uint componentHash = (uint)GetHashKey(comp);
+                        if (DoesWeaponTakeWeaponComponent(hash, componentHash))
+                        {
+                            string componentName = weaponComponents[comp];
+                            if (!componentHashes.ContainsKey(componentName))
+                            {
+                                componentHashes[componentName] = componentHash;
+                            }
+                        }
+                    }
+                    var avw = new ValidAddonWeapon
+                    {
+                        Hash = hash,
+                        SpawnName = realName,
+                        Name = localizedName,
+                        AddonComponents = componentHashes,
+                    };
+                    if (!_addonWeaponsList.Contains(avw))
+                    {
+                        _addonWeaponsList.Add(avw);
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/vMenu/data/ValidWeapon.cs
+++ b/vMenu/data/ValidWeapon.cs
@@ -56,6 +56,51 @@ namespace vMenuClient.data
         }
     }
 
+    public struct ValidAddonWeapon
+    {
+        public uint Hash;
+        public string Name;
+        public Dictionary<string, uint> Components;
+        public string SpawnName;
+        public readonly int GetMaxAmmo
+        {
+            get
+            {
+                var ammo = 0; GetMaxAmmo(Game.PlayerPed.Handle, Hash, ref ammo); return ammo;
+            }
+        }
+        public int CurrentAmmo;
+        public int CurrentTint;
+        public readonly float Accuracy
+        {
+            get
+            {
+                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudAccuracy;
+            }
+        }
+        public readonly float Damage
+        {
+            get
+            {
+                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudDamage;
+            }
+        }
+        public readonly float Range
+        {
+            get
+            {
+                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudRange;
+            }
+        }
+        public readonly float Speed
+        {
+            get
+            {
+                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudSpeed;
+            }
+        }
+    }
+
     public static class ValidWeapons
     {
         private static readonly List<ValidWeapon> _weaponsList = new();
@@ -991,6 +1036,533 @@ namespace vMenuClient.data
             ["Metallic Red & Yellow"] = 31
         };
         #endregion
+        #endregion
+    }
+
+    public static class ValidAddonWeapons
+    {
+        private static readonly List<ValidAddonWeapon> _addonWeaponsList = new();
+
+        public static List<ValidAddonWeapon> AddonWeaponsList
+        {
+            get
+            {
+                var addons = LoadResourceFile(GetCurrentResourceName(), "config/addons.json") ?? "{}";
+                var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
+                if (_addonWeaponsList.Count == addonsFile["weapons"].Count - 1)
+                {
+                    return _addonWeaponsList;
+                }
+                CreateWeaponsList();
+                return _addonWeaponsList;
+            }
+        }
+
+        private static Dictionary<string, string> _components = new();
+        public static Dictionary<string, string> GetWeaponComponents()
+        {
+            if (_components.Count == 0)
+            {
+                var addons = LoadResourceFile(GetCurrentResourceName(), "config/addons.json") ?? "{}";
+                _components = weaponComponentNames;
+                try
+                {
+                    var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
+                    if (addonsFile.ContainsKey("weapon_components"))
+                    {
+                        foreach (var item in addonsFile["weapon_components"])
+                        {
+                            var name = item;
+                            var displayName = GetLabelText(name) ?? name;
+                            var unused = 0;
+                            if (GetWeaponComponentHudStats((uint)GetHashKey(name), ref unused))
+                            {
+                                _components.Add(name, displayName);
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    Log("[WARNING] The addons.json contains invalid JSON.");
+                }
+            }
+            return _components;
+        }
+
+        private static void CreateWeaponsList()
+        {
+            _addonWeaponsList.Clear();
+            var addons = LoadResourceFile(GetCurrentResourceName(), "config/addons.json") ?? "{}";
+            var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
+            if (addonsFile.ContainsKey("weapons"))
+            {
+                //convert list in addons.json to key value pair dictionary
+                Dictionary<string, string> keyValuePairs = new Dictionary<string, string>();
+                foreach (var key in addonsFile["weapons"])
+                {
+                    // Caluculates the Value based of the key in addons.json
+                    string value = key;
+                    // Add the key-value pair to the dictionary
+                    keyValuePairs[value] = GetLabelText(value);
+                }
+                foreach (var addonWeapon in keyValuePairs)
+                {
+                    var realName = addonWeapon.Key;
+                    var localizedName = addonWeapon.Value;
+                    if (realName != "weapon_unarmed")
+                    {
+                        var hash = (uint)GetHashKey(addonWeapon.Key);
+                        var componentHashes = new Dictionary<string, uint>();
+                        foreach (var comp in GetWeaponComponents().Keys)
+                        {
+                            if (DoesWeaponTakeWeaponComponent(hash, (uint)GetHashKey(comp)))
+                            {
+                                if (!componentHashes.ContainsKey(GetWeaponComponents()[comp]))
+                                {
+                                    componentHashes.Add(GetWeaponComponents()[comp], (uint)GetHashKey(comp));
+                                }
+                            }
+                        }
+                        var avw = new ValidAddonWeapon()
+                        {
+                            Hash = hash,
+                            SpawnName = realName,
+                            Name = localizedName,
+                            Components = componentHashes,
+                        };
+                        if (!_addonWeaponsList.Contains(avw))
+                        {
+                            _addonWeaponsList.Add(avw);
+                        }
+                    }
+                }
+            }
+        }
+
+        #region weapon component names
+        private static readonly Dictionary<string, string> weaponComponentNames = new()
+        {
+            ["COMPONENT_ADVANCEDRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_ADVANCEDRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_ADVANCEDRIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_METAL"),
+            ["COMPONENT_APPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_APPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_APPISTOL_VARMOD_LUXE"] = GetLabelText("WCT_VAR_METAL"),
+            ["COMPONENT_ASSAULTRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_ASSAULTRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_ASSAULTRIFLE_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_ASSAULTRIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_ASSAULTSHOTGUN_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_ASSAULTSHOTGUN_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_ASSAULTSMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_ASSAULTSMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_ASSAULTSMG_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_AT_AR_AFGRIP_02"] = GetLabelText("WCT_GRIP"),
+            ["COMPONENT_AT_AR_AFGRIP"] = GetLabelText("WCT_GRIP"),
+            ["COMPONENT_AT_AR_BARREL_01"] = GetLabelText("WCT_BARR"),
+            ["COMPONENT_AT_AR_BARREL_02"] = GetLabelText("WCT_BARR2"),
+            ["COMPONENT_AT_AR_FLSH"] = GetLabelText("WCT_FLASH"),
+            ["COMPONENT_AT_AR_SUPP_02"] = GetLabelText("WCT_SUPP"),
+            ["COMPONENT_AT_AR_SUPP"] = GetLabelText("WCT_SUPP"),
+            ["COMPONENT_AT_BP_BARREL_01"] = GetLabelText("WCT_BARR"),
+            ["COMPONENT_AT_BP_BARREL_02"] = GetLabelText("WCT_BARR2"),
+            ["COMPONENT_AT_CR_BARREL_01"] = GetLabelText("WCT_BARR"),
+            ["COMPONENT_AT_CR_BARREL_02"] = GetLabelText("WCT_BARR2"),
+            ["COMPONENT_AT_MG_BARREL_01"] = GetLabelText("WCT_BARR"),
+            ["COMPONENT_AT_MG_BARREL_02"] = GetLabelText("WCT_BARR2"),
+            ["COMPONENT_AT_MRFL_BARREL_01"] = GetLabelText("WCT_BARR"),
+            ["COMPONENT_AT_MRFL_BARREL_02"] = GetLabelText("WCT_BARR2"),
+            ["COMPONENT_AT_MUZZLE_01"] = GetLabelText("WCT_MUZZ1"),
+            ["COMPONENT_AT_MUZZLE_02"] = GetLabelText("WCT_MUZZ2"),
+            ["COMPONENT_AT_MUZZLE_03"] = GetLabelText("WCT_MUZZ3"),
+            ["COMPONENT_AT_MUZZLE_04"] = GetLabelText("WCT_MUZZ4"),
+            ["COMPONENT_AT_MUZZLE_05"] = GetLabelText("WCT_MUZZ5"),
+            ["COMPONENT_AT_MUZZLE_06"] = GetLabelText("WCT_MUZZ6"),
+            ["COMPONENT_AT_MUZZLE_07"] = GetLabelText("WCT_MUZZ7"),
+            ["COMPONENT_AT_MUZZLE_08"] = GetLabelText("WCT_MUZZ"),
+            ["COMPONENT_AT_MUZZLE_09"] = GetLabelText("WCT_MUZZ9"),
+            ["COMPONENT_AT_PI_COMP_02"] = GetLabelText("WCT_COMP"),
+            ["COMPONENT_AT_PI_COMP_03"] = GetLabelText("WCT_COMP"),
+            ["COMPONENT_AT_PI_COMP"] = GetLabelText("WCT_COMP"),
+            ["COMPONENT_AT_PI_FLSH_02"] = GetLabelText("WCT_FLASH"),
+            ["COMPONENT_AT_PI_FLSH_03"] = GetLabelText("WCT_FLASH"),
+            ["COMPONENT_AT_PI_FLSH"] = GetLabelText("WCT_FLASH"),
+            ["COMPONENT_AT_PI_RAIL_02"] = GetLabelText("WCT_SCOPE_PI"),
+            ["COMPONENT_AT_PI_RAIL"] = GetLabelText("WCT_SCOPE_PI"),
+            ["COMPONENT_AT_PI_SUPP_02"] = GetLabelText("WCT_SUPP"),
+            ["COMPONENT_AT_PI_SUPP"] = GetLabelText("WCT_SUPP"),
+            ["COMPONENT_AT_SB_BARREL_01"] = GetLabelText("WCT_BARR"),
+            ["COMPONENT_AT_SB_BARREL_02"] = GetLabelText("WCT_BARR2"),
+            ["COMPONENT_AT_SC_BARREL_01"] = GetLabelText("WCT_BARR"),
+            ["COMPONENT_AT_SC_BARREL_02"] = GetLabelText("WCT_BARR2"),
+            ["COMPONENT_AT_SCOPE_LARGE_FIXED_ZOOM_MK2"] = GetLabelText("WCT_SCOPE_LRG2"),
+            ["COMPONENT_AT_SCOPE_LARGE_FIXED_ZOOM"] = GetLabelText("WCT_SCOPE_LRG"),
+            ["COMPONENT_AT_SCOPE_LARGE_MK2"] = GetLabelText("WCT_SCOPE_LRG2"),
+            ["COMPONENT_AT_SCOPE_LARGE"] = GetLabelText("WCT_SCOPE_LRG"),
+            ["COMPONENT_AT_SCOPE_MACRO_02_MK2"] = GetLabelText("WCT_SCOPE_MAC2"),
+            ["COMPONENT_AT_SCOPE_MACRO_02_SMG_MK2"] = GetLabelText("WCT_SCOPE_MAC2"),
+            ["COMPONENT_AT_SCOPE_MACRO_02"] = GetLabelText("WCT_SCOPE_MAC"),
+            ["COMPONENT_AT_SCOPE_MACRO_MK2"] = GetLabelText("WCT_SCOPE_MAC2"),
+            ["COMPONENT_AT_SCOPE_MACRO"] = GetLabelText("WCT_SCOPE_MAC"),
+            ["COMPONENT_AT_SCOPE_MAX"] = GetLabelText("WCT_SCOPE_MAX"),
+            ["COMPONENT_AT_SCOPE_MEDIUM_MK2"] = GetLabelText("WCT_SCOPE_MED2"),
+            ["COMPONENT_AT_SCOPE_MEDIUM"] = GetLabelText("WCT_SCOPE_LRG"),
+            ["COMPONENT_AT_SCOPE_NV"] = GetLabelText("WCT_SCOPE_NV"),
+            ["COMPONENT_AT_SCOPE_SMALL_02"] = GetLabelText("WCT_SCOPE_SML"),
+            ["COMPONENT_AT_SCOPE_SMALL_MK2"] = GetLabelText("WCT_SCOPE_SML2"),
+            ["COMPONENT_AT_SCOPE_SMALL_SMG_MK2"] = GetLabelText("WCT_SCOPE_SML2"),
+            ["COMPONENT_AT_SCOPE_SMALL"] = GetLabelText("WCT_SCOPE_SML"),
+            ["COMPONENT_AT_SCOPE_THERMAL"] = GetLabelText("WCT_SCOPE_TH"),
+            ["COMPONENT_AT_SIGHTS_SMG"] = GetLabelText("WCT_HOLO"),
+            ["COMPONENT_AT_SIGHTS"] = GetLabelText("WCT_HOLO"),
+            ["COMPONENT_AT_SR_BARREL_01"] = GetLabelText("WCT_BARR"),
+            ["COMPONENT_AT_SR_BARREL_02"] = GetLabelText("WCT_BARR2"),
+            ["COMPONENT_AT_SR_SUPP_03"] = GetLabelText("WCT_SUPP"),
+            ["COMPONENT_AT_SR_SUPP"] = GetLabelText("WCT_SUPP"),
+            ["COMPONENT_BULLPUPRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_BULLPUPRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_BULLPUPRIFLE_VARMOD_LOW"] = GetLabelText("WCT_VAR_METAL"),
+            ["COMPONENT_CARBINERIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_CARBINERIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_CARBINERIFLE_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_CARBINERIFLE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_CARBINERIFLE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_CARBINERIFLE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_CARBINERIFLE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
+            ["COMPONENT_CARBINERIFLE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_CARBINERIFLE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_CARBINERIFLE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_CARBINERIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_COMBATMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_COMBATMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_COMBATMG_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_COMBATMG_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_COMBATMG_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_COMBATMG_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_COMBATMG_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
+            ["COMPONENT_COMBATMG_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_COMBATMG_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_COMBATMG_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_COMBATPDW_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_COMBATPDW_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_COMBATPDW_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
+            ["COMPONENT_COMBATPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_COMBATPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_COMBATPISTOL_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_COMPACTRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_COMPACTRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_COMPACTRIFLE_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
+            ["COMPONENT_GUSENBERG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_GUSENBERG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_HEAVYPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_HEAVYPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_HEAVYPISTOL_VARMOD_LUXE"] = GetLabelText("WCT_VAR_WOOD"),
+            ["COMPONENT_HEAVYSHOTGUN_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_HEAVYSHOTGUN_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_HEAVYSHOTGUN_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_EXPLOSIVE"] = GetLabelText("WCT_CLIP_EX"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_KNUCKLE_VARMOD_BALLAS"] = GetLabelText("WCT_KNUCK_BG"),
+            ["COMPONENT_KNUCKLE_VARMOD_BASE"] = GetLabelText("WCT_KNUCK_01"),
+            ["COMPONENT_KNUCKLE_VARMOD_DIAMOND"] = GetLabelText("WCT_KNUCK_DMD"),
+            ["COMPONENT_KNUCKLE_VARMOD_DOLLAR"] = GetLabelText("WCT_KNUCK_DLR"),
+            ["COMPONENT_KNUCKLE_VARMOD_HATE"] = GetLabelText("WCT_KNUCK_HT"),
+            ["COMPONENT_KNUCKLE_VARMOD_KING"] = GetLabelText("WCT_KNUCK_SLG"),
+            ["COMPONENT_KNUCKLE_VARMOD_LOVE"] = GetLabelText("WCT_KNUCK_LV"),
+            ["COMPONENT_KNUCKLE_VARMOD_PIMP"] = GetLabelText("WCT_KNUCK_02"),
+            ["COMPONENT_KNUCKLE_VARMOD_PLAYER"] = GetLabelText("WCT_KNUCK_PC"),
+            ["COMPONENT_KNUCKLE_VARMOD_VAGOS"] = GetLabelText("WCT_KNUCK_VG"),
+            ["COMPONENT_MACHINEPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_MACHINEPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_MACHINEPISTOL_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
+            ["COMPONENT_MARKSMANRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_MARKSMANRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_MARKSMANRIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_MG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_MG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_MG_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_MICROSMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_MICROSMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_MICROSMG_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_MINISMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_MINISMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_PISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_PISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_PISTOL_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_PISTOL_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_PISTOL_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_PISTOL_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_PISTOL_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_PISTOL_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_PISTOL_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_PISTOL_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_PISTOL_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_PISTOL_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_PISTOL_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_PISTOL_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_PISTOL_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_PISTOL_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_PISTOL_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_CLIP_HP"),
+            ["COMPONENT_PISTOL_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_PISTOL_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_PISTOL_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_PISTOL50_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_PISTOL50_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_PISTOL50_VARMOD_LUXE"] = GetLabelText("WCT_VAR_SIL"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_01"] = GetLabelText("WCT_SHELL"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_SHELL_AP"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_EXPLOSIVE"] = GetLabelText("WCT_SHELL_EX"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_SHELL_HP"),
+            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_SHELL_INC"),
+            ["COMPONENT_PUMPSHOTGUN_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_REVOLVER_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_REVOLVER_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_REVOLVER_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1_RV"),
+            ["COMPONENT_REVOLVER_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_REVOLVER_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_CLIP_HP"),
+            ["COMPONENT_REVOLVER_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_REVOLVER_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_REVOLVER_VARMOD_BOSS"] = GetLabelText("WCT_REV_VARB"),
+            ["COMPONENT_REVOLVER_VARMOD_GOON"] = GetLabelText("WCT_REV_VARG"),
+            ["COMPONENT_SAWNOFFSHOTGUN_VARMOD_LUXE"] = GetLabelText("WCT_VAR_METAL"),
+            ["COMPONENT_SMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_SMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_SMG_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
+            ["COMPONENT_SMG_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_SMG_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_SMG_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_SMG_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_SMG_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_SMG_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_SMG_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_SMG_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_SMG_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_SMG_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_SMG_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_SMG_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_SMG_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_SMG_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_SMG_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_CLIP_HP"),
+            ["COMPONENT_SMG_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_SMG_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_SMG_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
+            ["COMPONENT_SNIPERRIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_WOOD"),
+            ["COMPONENT_SNSPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_SNSPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_SNSPISTOL_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_SNSPISTOL_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_SNSPISTOL_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_SNSPISTOL_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_SNSPISTOL_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_CLIP_HP"),
+            ["COMPONENT_SNSPISTOL_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_SNSPISTOL_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_SNSPISTOL_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_WOOD"),
+            ["COMPONENT_SPECIALCARBINE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_SPECIALCARBINE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_SPECIALCARBINE_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
+            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
+            ["COMPONENT_SPECIALCARBINE_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_ETCHM"),
+            ["COMPONENT_SWITCHBLADE_VARMOD_BASE"] = GetLabelText("WCT_SB_BASE"),
+            ["COMPONENT_SWITCHBLADE_VARMOD_VAR1"] = GetLabelText("WCT_SB_VAR1"),
+            ["COMPONENT_SWITCHBLADE_VARMOD_VAR2"] = GetLabelText("WCT_SB_VAR2"),
+            ["COMPONENT_VINTAGEPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_VINTAGEPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_RAYPISTOL_VARMOD_XMAS18"] = GetLabelText("WCT_VAR_RAY18"),
+            // MPHEIST3 DLC (v 1868)
+            ["COMPONENT_CERAMICPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_CERAMICPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_CERAMICPISTOL_SUPP"] = GetLabelText("WCT_SUPP"),
+            // MPHEIST4 DLC (v 2189)
+            ["COMPONENT_MILITARYRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_MILITARYRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_MILITARYRIFLE_SIGHT_01"] = GetLabelText("WCT_MRFL_SIGHT"),
+            // MPSECURITY DLC (v 2545)
+            ["COMPONENT_APPISTOL_VARMOD_SECURITY"] = GetLabelText("WCT_VAR_STUD"),
+            ["COMPONENT_MICROSMG_VARMOD_SECURITY"] = GetLabelText("WCT_VAR_WEED"),
+            ["COMPONENT_PUMPSHOTGUN_VARMOD_SECURITY"] = GetLabelText("WCT_VAR_BONE"),
+            ["COMPONENT_HEAVYRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_HEAVYRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_HEAVYRIFLE_SIGHT_01"] = GetLabelText("WCT_HVYRFLE_SIG"),
+            ["COMPONENT_HEAVYRIFLE_CAMO1"] = GetLabelText("WCT_VAR_FAM"),
+            // MPSUM2 DLC (V 2699)
+            ["COMPONENT_TACTICALRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_TACTICALRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_PRECISIONRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_AT_AR_FLSH_REH"] = GetLabelText("WCT_FLASH"),
+            // MPCHRISTMAS3 DLC (V 2802)
+            ["COMPONENT_PISTOLXM3_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_PISTOLXM3_SUPP"] = GetLabelText("WCT_SUPP"),
+            ["COMPONENT_MICROSMG_VARMOD_XM3"] = GetLabelText("WCT_MSMG_XM3"),
+            ["COMPONENT_PUMPSHOTGUN_VARMOD_XM3"] = GetLabelText("WCT_PUMPSHT_XM3"),
+            ["COMPONENT_PISTOL_MK2_VARMOD_XM3"] = GetLabelText("WCT_PISTMK2_XM3"),
+            ["COMPONENT_PISTOL_MK2_VARMOD_XM3_SLIDE"] = GetLabelText("WCT_PISTMK2_XM3"),
+            ["COMPONENT_BAT_VARMOD_XM3"] = GetLabelText("WCT_BAT_XM3"),
+            ["COMPONENT_BAT_VARMOD_XM3_01"] = GetLabelText("WCT_BAT_XM301"),
+            ["COMPONENT_BAT_VARMOD_XM3_02"] = GetLabelText("WCT_BAT_XM302"),
+            ["COMPONENT_BAT_VARMOD_XM3_03"] = GetLabelText("WCT_BAT_XM303"),
+            ["COMPONENT_BAT_VARMOD_XM3_04"] = GetLabelText("WCT_BAT_XM304"),
+            ["COMPONENT_BAT_VARMOD_XM3_05"] = GetLabelText("WCT_BAT_XM305"),
+            ["COMPONENT_BAT_VARMOD_XM3_06"] = GetLabelText("WCT_BAT_XM306"),
+            ["COMPONENT_BAT_VARMOD_XM3_07"] = GetLabelText("WCT_BAT_XM307"),
+            ["COMPONENT_BAT_VARMOD_XM3_08"] = GetLabelText("WCT_BAT_XM308"),
+            ["COMPONENT_BAT_VARMOD_XM3_09"] = GetLabelText("WCT_BAT_XM309"),
+            ["COMPONENT_KNIFE_VARMOD_XM3"] = GetLabelText("WCT_KNIFE_XM3"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_01"] = GetLabelText("WCT_KNIFE_XM301"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_02"] = GetLabelText("WCT_KNIFE_XM302"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_03"] = GetLabelText("WCT_KNIFE_XM303"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_04"] = GetLabelText("WCT_KNIFE_XM304"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_05"] = GetLabelText("WCT_KNIFE_XM305"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_06"] = GetLabelText("WCT_KNIFE_XM306"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_07"] = GetLabelText("WCT_KNIFE_XM307"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_08"] = GetLabelText("WCT_KNIFE_XM308"),
+            ["COMPONENT_KNIFE_VARMOD_XM3_09"] = GetLabelText("WCT_KNIFE_XM309"),
+            // MP2023_01 DLC (V 2944)
+            ["COMPONENT_TECPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_TECPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_MICROSMG_VARMOD_FRN"] = GetLabelText("WCT_MSMGFRN_VAR"),
+            ["COMPONENT_CARBINERIFLE_VARMOD_MICH"] = GetLabelText("WCT_CRBNMIC_VAR"),
+            ["COMPONENT_RPG_VARMOD_TVR"] = GetLabelText("WCT_RPGTVR_VAR"),
+            // MP2023_02 DLC (V 3095)
+            ["COMPONENT_BATTLERIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
+            ["COMPONENT_BATTLERIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
+            ["COMPONENT_COMBATPISTOL_VARMOD_XMAS23"] = GetLabelText("WCT_COMPIST_XM"),
+            ["COMPONENT_SPECIALCARBINE_VARMOD_XMAS23"] = GetLabelText("WCT_SPCR_XM"),
+            ["COMPONENT_HEAVYSNIPER_VARMOD_XMAS23"] = GetLabelText("WCT_HVSP_XM"),
+            // MP2024_01 DLC (V 3258)
+            ["COMPONENT_STUNGUN_VARMOD_BAIL"] = GetLabelText("WCT_STNGN_BAIL"),
+        };
         #endregion
     }
 }

--- a/vMenu/data/ValidWeapon.cs
+++ b/vMenu/data/ValidWeapon.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using CitizenFX.Core;
@@ -56,51 +57,6 @@ namespace vMenuClient.data
         }
     }
 
-    public struct ValidAddonWeapon
-    {
-        public uint Hash;
-        public string Name;
-        public Dictionary<string, uint> Components;
-        public string SpawnName;
-        public readonly int GetMaxAmmo
-        {
-            get
-            {
-                var ammo = 0; GetMaxAmmo(Game.PlayerPed.Handle, Hash, ref ammo); return ammo;
-            }
-        }
-        public int CurrentAmmo;
-        public int CurrentTint;
-        public readonly float Accuracy
-        {
-            get
-            {
-                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudAccuracy;
-            }
-        }
-        public readonly float Damage
-        {
-            get
-            {
-                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudDamage;
-            }
-        }
-        public readonly float Range
-        {
-            get
-            {
-                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudRange;
-            }
-        }
-        public readonly float Speed
-        {
-            get
-            {
-                var stats = new Game.WeaponHudStats(); Game.GetWeaponHudStats(Hash, ref stats); return stats.hudSpeed;
-            }
-        }
-    }
-
     public static class ValidWeapons
     {
         private static readonly List<ValidWeapon> _weaponsList = new();
@@ -118,7 +74,6 @@ namespace vMenuClient.data
             }
         }
 
-
         private static Dictionary<string, string> _components = new();
         public static Dictionary<string, string> GetWeaponComponents()
         {
@@ -129,21 +84,16 @@ namespace vMenuClient.data
                 try
                 {
                     var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
-                    if (addonsFile.ContainsKey("weapon_components"))
+
+                    if (addonsFile.TryGetValue("weapon_components", out var weaponComponents))
                     {
-                        foreach (var item in addonsFile["weapon_components"])
+                        foreach (var key in weaponComponents)
                         {
-                            var name = item;
-                            var displayName = GetLabelText(name) ?? name;
-                            var unused = 0;
-                            if (GetWeaponComponentHudStats((uint)GetHashKey(name), ref unused))
-                            {
-                                _components.Add(name, displayName);
-                            }
+                            _components[key] = key;
                         }
                     }
                 }
-                catch
+                catch (JsonException)
                 {
                     Log("[WARNING] The addons.json contains invalid JSON.");
                 }
@@ -158,32 +108,34 @@ namespace vMenuClient.data
             {
                 var realName = weapon.Key;
                 var localizedName = weapon.Value;
-                if (realName != "weapon_unarmed")
+                if (realName == "weapon_unarmed") continue;
+                var hash = (uint)GetHashKey(realName);
+                var componentHashes = new Dictionary<string, uint>();
+                var weaponComponents = GetWeaponComponents();
+                var weaponComponentKeys = weaponComponents.Keys;
+                foreach (var comp in weaponComponentKeys)
                 {
-                    var hash = (uint)GetHashKey(weapon.Key);
-                    var componentHashes = new Dictionary<string, uint>();
-                    foreach (var comp in GetWeaponComponents().Keys)
+                    var componentHash = (uint)GetHashKey(comp);
+                    if (DoesWeaponTakeWeaponComponent(hash, componentHash))
                     {
-                        if (DoesWeaponTakeWeaponComponent(hash, (uint)GetHashKey(comp)))
+                        var componentName = weaponComponents[comp];
+                        if (!componentHashes.ContainsKey(componentName))
                         {
-                            if (!componentHashes.ContainsKey(GetWeaponComponents()[comp]))
-                            {
-                                componentHashes.Add(GetWeaponComponents()[comp], (uint)GetHashKey(comp));
-                            }
+                            componentHashes[componentName] = componentHash;
                         }
                     }
-                    var vw = new ValidWeapon()
-                    {
-                        Hash = hash,
-                        SpawnName = realName,
-                        Name = localizedName,
-                        Components = componentHashes,
-                        Perm = weaponPermissions[realName]
-                    };
-                    if (!_weaponsList.Contains(vw))
-                    {
-                        _weaponsList.Add(vw);
-                    }
+                }
+                var vw = new ValidWeapon
+                {
+                    Hash = hash,
+                    SpawnName = realName,
+                    Name = localizedName,
+                    Components = componentHashes,
+                    Perm = weaponPermissions[realName]
+                };
+                if (!_weaponsList.Contains(vw))
+                {
+                    _weaponsList.Add(vw);
                 }
             }
         }
@@ -1036,533 +988,6 @@ namespace vMenuClient.data
             ["Metallic Red & Yellow"] = 31
         };
         #endregion
-        #endregion
-    }
-
-    public static class ValidAddonWeapons
-    {
-        private static readonly List<ValidAddonWeapon> _addonWeaponsList = new();
-
-        public static List<ValidAddonWeapon> AddonWeaponsList
-        {
-            get
-            {
-                var addons = LoadResourceFile(GetCurrentResourceName(), "config/addons.json") ?? "{}";
-                var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
-                if (_addonWeaponsList.Count == addonsFile["weapons"].Count - 1)
-                {
-                    return _addonWeaponsList;
-                }
-                CreateWeaponsList();
-                return _addonWeaponsList;
-            }
-        }
-
-        private static Dictionary<string, string> _components = new();
-        public static Dictionary<string, string> GetWeaponComponents()
-        {
-            if (_components.Count == 0)
-            {
-                var addons = LoadResourceFile(GetCurrentResourceName(), "config/addons.json") ?? "{}";
-                _components = weaponComponentNames;
-                try
-                {
-                    var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
-                    if (addonsFile.ContainsKey("weapon_components"))
-                    {
-                        foreach (var item in addonsFile["weapon_components"])
-                        {
-                            var name = item;
-                            var displayName = GetLabelText(name) ?? name;
-                            var unused = 0;
-                            if (GetWeaponComponentHudStats((uint)GetHashKey(name), ref unused))
-                            {
-                                _components.Add(name, displayName);
-                            }
-                        }
-                    }
-                }
-                catch
-                {
-                    Log("[WARNING] The addons.json contains invalid JSON.");
-                }
-            }
-            return _components;
-        }
-
-        private static void CreateWeaponsList()
-        {
-            _addonWeaponsList.Clear();
-            var addons = LoadResourceFile(GetCurrentResourceName(), "config/addons.json") ?? "{}";
-            var addonsFile = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(addons);
-            if (addonsFile.ContainsKey("weapons"))
-            {
-                //convert list in addons.json to key value pair dictionary
-                Dictionary<string, string> keyValuePairs = new Dictionary<string, string>();
-                foreach (var key in addonsFile["weapons"])
-                {
-                    // Caluculates the Value based of the key in addons.json
-                    string value = key;
-                    // Add the key-value pair to the dictionary
-                    keyValuePairs[value] = GetLabelText(value);
-                }
-                foreach (var addonWeapon in keyValuePairs)
-                {
-                    var realName = addonWeapon.Key;
-                    var localizedName = addonWeapon.Value;
-                    if (realName != "weapon_unarmed")
-                    {
-                        var hash = (uint)GetHashKey(addonWeapon.Key);
-                        var componentHashes = new Dictionary<string, uint>();
-                        foreach (var comp in GetWeaponComponents().Keys)
-                        {
-                            if (DoesWeaponTakeWeaponComponent(hash, (uint)GetHashKey(comp)))
-                            {
-                                if (!componentHashes.ContainsKey(GetWeaponComponents()[comp]))
-                                {
-                                    componentHashes.Add(GetWeaponComponents()[comp], (uint)GetHashKey(comp));
-                                }
-                            }
-                        }
-                        var avw = new ValidAddonWeapon()
-                        {
-                            Hash = hash,
-                            SpawnName = realName,
-                            Name = localizedName,
-                            Components = componentHashes,
-                        };
-                        if (!_addonWeaponsList.Contains(avw))
-                        {
-                            _addonWeaponsList.Add(avw);
-                        }
-                    }
-                }
-            }
-        }
-
-        #region weapon component names
-        private static readonly Dictionary<string, string> weaponComponentNames = new()
-        {
-            ["COMPONENT_ADVANCEDRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_ADVANCEDRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_ADVANCEDRIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_METAL"),
-            ["COMPONENT_APPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_APPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_APPISTOL_VARMOD_LUXE"] = GetLabelText("WCT_VAR_METAL"),
-            ["COMPONENT_ASSAULTRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_ASSAULTRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_ASSAULTRIFLE_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_ASSAULTRIFLE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_ASSAULTRIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_ASSAULTSHOTGUN_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_ASSAULTSHOTGUN_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_ASSAULTSMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_ASSAULTSMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_ASSAULTSMG_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_AT_AR_AFGRIP_02"] = GetLabelText("WCT_GRIP"),
-            ["COMPONENT_AT_AR_AFGRIP"] = GetLabelText("WCT_GRIP"),
-            ["COMPONENT_AT_AR_BARREL_01"] = GetLabelText("WCT_BARR"),
-            ["COMPONENT_AT_AR_BARREL_02"] = GetLabelText("WCT_BARR2"),
-            ["COMPONENT_AT_AR_FLSH"] = GetLabelText("WCT_FLASH"),
-            ["COMPONENT_AT_AR_SUPP_02"] = GetLabelText("WCT_SUPP"),
-            ["COMPONENT_AT_AR_SUPP"] = GetLabelText("WCT_SUPP"),
-            ["COMPONENT_AT_BP_BARREL_01"] = GetLabelText("WCT_BARR"),
-            ["COMPONENT_AT_BP_BARREL_02"] = GetLabelText("WCT_BARR2"),
-            ["COMPONENT_AT_CR_BARREL_01"] = GetLabelText("WCT_BARR"),
-            ["COMPONENT_AT_CR_BARREL_02"] = GetLabelText("WCT_BARR2"),
-            ["COMPONENT_AT_MG_BARREL_01"] = GetLabelText("WCT_BARR"),
-            ["COMPONENT_AT_MG_BARREL_02"] = GetLabelText("WCT_BARR2"),
-            ["COMPONENT_AT_MRFL_BARREL_01"] = GetLabelText("WCT_BARR"),
-            ["COMPONENT_AT_MRFL_BARREL_02"] = GetLabelText("WCT_BARR2"),
-            ["COMPONENT_AT_MUZZLE_01"] = GetLabelText("WCT_MUZZ1"),
-            ["COMPONENT_AT_MUZZLE_02"] = GetLabelText("WCT_MUZZ2"),
-            ["COMPONENT_AT_MUZZLE_03"] = GetLabelText("WCT_MUZZ3"),
-            ["COMPONENT_AT_MUZZLE_04"] = GetLabelText("WCT_MUZZ4"),
-            ["COMPONENT_AT_MUZZLE_05"] = GetLabelText("WCT_MUZZ5"),
-            ["COMPONENT_AT_MUZZLE_06"] = GetLabelText("WCT_MUZZ6"),
-            ["COMPONENT_AT_MUZZLE_07"] = GetLabelText("WCT_MUZZ7"),
-            ["COMPONENT_AT_MUZZLE_08"] = GetLabelText("WCT_MUZZ"),
-            ["COMPONENT_AT_MUZZLE_09"] = GetLabelText("WCT_MUZZ9"),
-            ["COMPONENT_AT_PI_COMP_02"] = GetLabelText("WCT_COMP"),
-            ["COMPONENT_AT_PI_COMP_03"] = GetLabelText("WCT_COMP"),
-            ["COMPONENT_AT_PI_COMP"] = GetLabelText("WCT_COMP"),
-            ["COMPONENT_AT_PI_FLSH_02"] = GetLabelText("WCT_FLASH"),
-            ["COMPONENT_AT_PI_FLSH_03"] = GetLabelText("WCT_FLASH"),
-            ["COMPONENT_AT_PI_FLSH"] = GetLabelText("WCT_FLASH"),
-            ["COMPONENT_AT_PI_RAIL_02"] = GetLabelText("WCT_SCOPE_PI"),
-            ["COMPONENT_AT_PI_RAIL"] = GetLabelText("WCT_SCOPE_PI"),
-            ["COMPONENT_AT_PI_SUPP_02"] = GetLabelText("WCT_SUPP"),
-            ["COMPONENT_AT_PI_SUPP"] = GetLabelText("WCT_SUPP"),
-            ["COMPONENT_AT_SB_BARREL_01"] = GetLabelText("WCT_BARR"),
-            ["COMPONENT_AT_SB_BARREL_02"] = GetLabelText("WCT_BARR2"),
-            ["COMPONENT_AT_SC_BARREL_01"] = GetLabelText("WCT_BARR"),
-            ["COMPONENT_AT_SC_BARREL_02"] = GetLabelText("WCT_BARR2"),
-            ["COMPONENT_AT_SCOPE_LARGE_FIXED_ZOOM_MK2"] = GetLabelText("WCT_SCOPE_LRG2"),
-            ["COMPONENT_AT_SCOPE_LARGE_FIXED_ZOOM"] = GetLabelText("WCT_SCOPE_LRG"),
-            ["COMPONENT_AT_SCOPE_LARGE_MK2"] = GetLabelText("WCT_SCOPE_LRG2"),
-            ["COMPONENT_AT_SCOPE_LARGE"] = GetLabelText("WCT_SCOPE_LRG"),
-            ["COMPONENT_AT_SCOPE_MACRO_02_MK2"] = GetLabelText("WCT_SCOPE_MAC2"),
-            ["COMPONENT_AT_SCOPE_MACRO_02_SMG_MK2"] = GetLabelText("WCT_SCOPE_MAC2"),
-            ["COMPONENT_AT_SCOPE_MACRO_02"] = GetLabelText("WCT_SCOPE_MAC"),
-            ["COMPONENT_AT_SCOPE_MACRO_MK2"] = GetLabelText("WCT_SCOPE_MAC2"),
-            ["COMPONENT_AT_SCOPE_MACRO"] = GetLabelText("WCT_SCOPE_MAC"),
-            ["COMPONENT_AT_SCOPE_MAX"] = GetLabelText("WCT_SCOPE_MAX"),
-            ["COMPONENT_AT_SCOPE_MEDIUM_MK2"] = GetLabelText("WCT_SCOPE_MED2"),
-            ["COMPONENT_AT_SCOPE_MEDIUM"] = GetLabelText("WCT_SCOPE_LRG"),
-            ["COMPONENT_AT_SCOPE_NV"] = GetLabelText("WCT_SCOPE_NV"),
-            ["COMPONENT_AT_SCOPE_SMALL_02"] = GetLabelText("WCT_SCOPE_SML"),
-            ["COMPONENT_AT_SCOPE_SMALL_MK2"] = GetLabelText("WCT_SCOPE_SML2"),
-            ["COMPONENT_AT_SCOPE_SMALL_SMG_MK2"] = GetLabelText("WCT_SCOPE_SML2"),
-            ["COMPONENT_AT_SCOPE_SMALL"] = GetLabelText("WCT_SCOPE_SML"),
-            ["COMPONENT_AT_SCOPE_THERMAL"] = GetLabelText("WCT_SCOPE_TH"),
-            ["COMPONENT_AT_SIGHTS_SMG"] = GetLabelText("WCT_HOLO"),
-            ["COMPONENT_AT_SIGHTS"] = GetLabelText("WCT_HOLO"),
-            ["COMPONENT_AT_SR_BARREL_01"] = GetLabelText("WCT_BARR"),
-            ["COMPONENT_AT_SR_BARREL_02"] = GetLabelText("WCT_BARR2"),
-            ["COMPONENT_AT_SR_SUPP_03"] = GetLabelText("WCT_SUPP"),
-            ["COMPONENT_AT_SR_SUPP"] = GetLabelText("WCT_SUPP"),
-            ["COMPONENT_BULLPUPRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_BULLPUPRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_BULLPUPRIFLE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_BULLPUPRIFLE_VARMOD_LOW"] = GetLabelText("WCT_VAR_METAL"),
-            ["COMPONENT_CARBINERIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_CARBINERIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_CARBINERIFLE_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_CARBINERIFLE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_CARBINERIFLE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_CARBINERIFLE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_CARBINERIFLE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
-            ["COMPONENT_CARBINERIFLE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_CARBINERIFLE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_CARBINERIFLE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_CARBINERIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_COMBATMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_COMBATMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_COMBATMG_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_COMBATMG_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_COMBATMG_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_COMBATMG_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_COMBATMG_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
-            ["COMPONENT_COMBATMG_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_COMBATMG_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_COMBATMG_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_COMBATPDW_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_COMBATPDW_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_COMBATPDW_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
-            ["COMPONENT_COMBATPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_COMBATPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_COMBATPISTOL_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_COMPACTRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_COMPACTRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_COMPACTRIFLE_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
-            ["COMPONENT_GUSENBERG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_GUSENBERG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_HEAVYPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_HEAVYPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_HEAVYPISTOL_VARMOD_LUXE"] = GetLabelText("WCT_VAR_WOOD"),
-            ["COMPONENT_HEAVYSHOTGUN_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_HEAVYSHOTGUN_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_HEAVYSHOTGUN_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_EXPLOSIVE"] = GetLabelText("WCT_CLIP_EX"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_HEAVYSNIPER_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_KNUCKLE_VARMOD_BALLAS"] = GetLabelText("WCT_KNUCK_BG"),
-            ["COMPONENT_KNUCKLE_VARMOD_BASE"] = GetLabelText("WCT_KNUCK_01"),
-            ["COMPONENT_KNUCKLE_VARMOD_DIAMOND"] = GetLabelText("WCT_KNUCK_DMD"),
-            ["COMPONENT_KNUCKLE_VARMOD_DOLLAR"] = GetLabelText("WCT_KNUCK_DLR"),
-            ["COMPONENT_KNUCKLE_VARMOD_HATE"] = GetLabelText("WCT_KNUCK_HT"),
-            ["COMPONENT_KNUCKLE_VARMOD_KING"] = GetLabelText("WCT_KNUCK_SLG"),
-            ["COMPONENT_KNUCKLE_VARMOD_LOVE"] = GetLabelText("WCT_KNUCK_LV"),
-            ["COMPONENT_KNUCKLE_VARMOD_PIMP"] = GetLabelText("WCT_KNUCK_02"),
-            ["COMPONENT_KNUCKLE_VARMOD_PLAYER"] = GetLabelText("WCT_KNUCK_PC"),
-            ["COMPONENT_KNUCKLE_VARMOD_VAGOS"] = GetLabelText("WCT_KNUCK_VG"),
-            ["COMPONENT_MACHINEPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_MACHINEPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_MACHINEPISTOL_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
-            ["COMPONENT_MARKSMANRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_MARKSMANRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_MARKSMANRIFLE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_MARKSMANRIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_MG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_MG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_MG_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_MICROSMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_MICROSMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_MICROSMG_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_MINISMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_MINISMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_PISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_PISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_PISTOL_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_PISTOL_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_PISTOL_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_PISTOL_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_PISTOL_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_PISTOL_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_PISTOL_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_PISTOL_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_PISTOL_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_PISTOL_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_PISTOL_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_PISTOL_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_PISTOL_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_PISTOL_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_PISTOL_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_CLIP_HP"),
-            ["COMPONENT_PISTOL_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_PISTOL_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_PISTOL_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_PISTOL50_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_PISTOL50_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_PISTOL50_VARMOD_LUXE"] = GetLabelText("WCT_VAR_SIL"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_01"] = GetLabelText("WCT_SHELL"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_SHELL_AP"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_EXPLOSIVE"] = GetLabelText("WCT_SHELL_EX"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_SHELL_HP"),
-            ["COMPONENT_PUMPSHOTGUN_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_SHELL_INC"),
-            ["COMPONENT_PUMPSHOTGUN_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_REVOLVER_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_REVOLVER_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_REVOLVER_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1_RV"),
-            ["COMPONENT_REVOLVER_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_REVOLVER_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_CLIP_HP"),
-            ["COMPONENT_REVOLVER_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_REVOLVER_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_REVOLVER_VARMOD_BOSS"] = GetLabelText("WCT_REV_VARB"),
-            ["COMPONENT_REVOLVER_VARMOD_GOON"] = GetLabelText("WCT_REV_VARG"),
-            ["COMPONENT_SAWNOFFSHOTGUN_VARMOD_LUXE"] = GetLabelText("WCT_VAR_METAL"),
-            ["COMPONENT_SMG_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_SMG_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_SMG_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
-            ["COMPONENT_SMG_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_SMG_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_SMG_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_SMG_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_SMG_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_SMG_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_SMG_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_SMG_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_SMG_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_SMG_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_SMG_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_SMG_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_SMG_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_SMG_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_SMG_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_CLIP_HP"),
-            ["COMPONENT_SMG_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_SMG_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_SMG_VARMOD_LUXE"] = GetLabelText("WCT_VAR_GOLD"),
-            ["COMPONENT_SNIPERRIFLE_VARMOD_LUXE"] = GetLabelText("WCT_VAR_WOOD"),
-            ["COMPONENT_SNSPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_SNSPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_SNSPISTOL_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_SNSPISTOL_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_SNSPISTOL_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_SNSPISTOL_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_SNSPISTOL_MK2_CLIP_HOLLOWPOINT"] = GetLabelText("WCT_CLIP_HP"),
-            ["COMPONENT_SNSPISTOL_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_SNSPISTOL_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_SNSPISTOL_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_WOOD"),
-            ["COMPONENT_SPECIALCARBINE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_SPECIALCARBINE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_SPECIALCARBINE_CLIP_03"] = GetLabelText("WCT_CLIP_DRM"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_02"] = GetLabelText("WCT_CAMO_2"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_03"] = GetLabelText("WCT_CAMO_3"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_04"] = GetLabelText("WCT_CAMO_4"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_05"] = GetLabelText("WCT_CAMO_5"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_06"] = GetLabelText("WCT_CAMO_6"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_07"] = GetLabelText("WCT_CAMO_7"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_08"] = GetLabelText("WCT_CAMO_8"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_09"] = GetLabelText("WCT_CAMO_9"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_10"] = GetLabelText("WCT_CAMO_10"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO_IND_01"] = GetLabelText("WCT_CAMO_IND"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CAMO"] = GetLabelText("WCT_CAMO_1"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_ARMORPIERCING"] = GetLabelText("WCT_CLIP_AP"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_FMJ"] = GetLabelText("WCT_CLIP_FMJ"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_INCENDIARY"] = GetLabelText("WCT_CLIP_INC"),
-            ["COMPONENT_SPECIALCARBINE_MK2_CLIP_TRACER"] = GetLabelText("WCT_CLIP_TR"),
-            ["COMPONENT_SPECIALCARBINE_VARMOD_LOWRIDER"] = GetLabelText("WCT_VAR_ETCHM"),
-            ["COMPONENT_SWITCHBLADE_VARMOD_BASE"] = GetLabelText("WCT_SB_BASE"),
-            ["COMPONENT_SWITCHBLADE_VARMOD_VAR1"] = GetLabelText("WCT_SB_VAR1"),
-            ["COMPONENT_SWITCHBLADE_VARMOD_VAR2"] = GetLabelText("WCT_SB_VAR2"),
-            ["COMPONENT_VINTAGEPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_VINTAGEPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_RAYPISTOL_VARMOD_XMAS18"] = GetLabelText("WCT_VAR_RAY18"),
-            // MPHEIST3 DLC (v 1868)
-            ["COMPONENT_CERAMICPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_CERAMICPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_CERAMICPISTOL_SUPP"] = GetLabelText("WCT_SUPP"),
-            // MPHEIST4 DLC (v 2189)
-            ["COMPONENT_MILITARYRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_MILITARYRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_MILITARYRIFLE_SIGHT_01"] = GetLabelText("WCT_MRFL_SIGHT"),
-            // MPSECURITY DLC (v 2545)
-            ["COMPONENT_APPISTOL_VARMOD_SECURITY"] = GetLabelText("WCT_VAR_STUD"),
-            ["COMPONENT_MICROSMG_VARMOD_SECURITY"] = GetLabelText("WCT_VAR_WEED"),
-            ["COMPONENT_PUMPSHOTGUN_VARMOD_SECURITY"] = GetLabelText("WCT_VAR_BONE"),
-            ["COMPONENT_HEAVYRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_HEAVYRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_HEAVYRIFLE_SIGHT_01"] = GetLabelText("WCT_HVYRFLE_SIG"),
-            ["COMPONENT_HEAVYRIFLE_CAMO1"] = GetLabelText("WCT_VAR_FAM"),
-            // MPSUM2 DLC (V 2699)
-            ["COMPONENT_TACTICALRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_TACTICALRIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_PRECISIONRIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_AT_AR_FLSH_REH"] = GetLabelText("WCT_FLASH"),
-            // MPCHRISTMAS3 DLC (V 2802)
-            ["COMPONENT_PISTOLXM3_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_PISTOLXM3_SUPP"] = GetLabelText("WCT_SUPP"),
-            ["COMPONENT_MICROSMG_VARMOD_XM3"] = GetLabelText("WCT_MSMG_XM3"),
-            ["COMPONENT_PUMPSHOTGUN_VARMOD_XM3"] = GetLabelText("WCT_PUMPSHT_XM3"),
-            ["COMPONENT_PISTOL_MK2_VARMOD_XM3"] = GetLabelText("WCT_PISTMK2_XM3"),
-            ["COMPONENT_PISTOL_MK2_VARMOD_XM3_SLIDE"] = GetLabelText("WCT_PISTMK2_XM3"),
-            ["COMPONENT_BAT_VARMOD_XM3"] = GetLabelText("WCT_BAT_XM3"),
-            ["COMPONENT_BAT_VARMOD_XM3_01"] = GetLabelText("WCT_BAT_XM301"),
-            ["COMPONENT_BAT_VARMOD_XM3_02"] = GetLabelText("WCT_BAT_XM302"),
-            ["COMPONENT_BAT_VARMOD_XM3_03"] = GetLabelText("WCT_BAT_XM303"),
-            ["COMPONENT_BAT_VARMOD_XM3_04"] = GetLabelText("WCT_BAT_XM304"),
-            ["COMPONENT_BAT_VARMOD_XM3_05"] = GetLabelText("WCT_BAT_XM305"),
-            ["COMPONENT_BAT_VARMOD_XM3_06"] = GetLabelText("WCT_BAT_XM306"),
-            ["COMPONENT_BAT_VARMOD_XM3_07"] = GetLabelText("WCT_BAT_XM307"),
-            ["COMPONENT_BAT_VARMOD_XM3_08"] = GetLabelText("WCT_BAT_XM308"),
-            ["COMPONENT_BAT_VARMOD_XM3_09"] = GetLabelText("WCT_BAT_XM309"),
-            ["COMPONENT_KNIFE_VARMOD_XM3"] = GetLabelText("WCT_KNIFE_XM3"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_01"] = GetLabelText("WCT_KNIFE_XM301"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_02"] = GetLabelText("WCT_KNIFE_XM302"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_03"] = GetLabelText("WCT_KNIFE_XM303"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_04"] = GetLabelText("WCT_KNIFE_XM304"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_05"] = GetLabelText("WCT_KNIFE_XM305"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_06"] = GetLabelText("WCT_KNIFE_XM306"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_07"] = GetLabelText("WCT_KNIFE_XM307"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_08"] = GetLabelText("WCT_KNIFE_XM308"),
-            ["COMPONENT_KNIFE_VARMOD_XM3_09"] = GetLabelText("WCT_KNIFE_XM309"),
-            // MP2023_01 DLC (V 2944)
-            ["COMPONENT_TECPISTOL_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_TECPISTOL_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_MICROSMG_VARMOD_FRN"] = GetLabelText("WCT_MSMGFRN_VAR"),
-            ["COMPONENT_CARBINERIFLE_VARMOD_MICH"] = GetLabelText("WCT_CRBNMIC_VAR"),
-            ["COMPONENT_RPG_VARMOD_TVR"] = GetLabelText("WCT_RPGTVR_VAR"),
-            // MP2023_02 DLC (V 3095)
-            ["COMPONENT_BATTLERIFLE_CLIP_01"] = GetLabelText("WCT_CLIP1"),
-            ["COMPONENT_BATTLERIFLE_CLIP_02"] = GetLabelText("WCT_CLIP2"),
-            ["COMPONENT_COMBATPISTOL_VARMOD_XMAS23"] = GetLabelText("WCT_COMPIST_XM"),
-            ["COMPONENT_SPECIALCARBINE_VARMOD_XMAS23"] = GetLabelText("WCT_SPCR_XM"),
-            ["COMPONENT_HEAVYSNIPER_VARMOD_XMAS23"] = GetLabelText("WCT_HVSP_XM"),
-            // MP2024_01 DLC (V 3258)
-            ["COMPONENT_STUNGUN_VARMOD_BAIL"] = GetLabelText("WCT_STNGN_BAIL"),
-        };
         #endregion
     }
 }

--- a/vMenu/menus/WeaponOptions.cs
+++ b/vMenu/menus/WeaponOptions.cs
@@ -26,6 +26,7 @@ namespace vMenuClient.menus
         public static Dictionary<string, uint> AddonWeapons = new();
 
         private Dictionary<Menu, ValidWeapon> weaponInfo;
+        private Dictionary<Menu, ValidAddonWeapon> addonWeaponInfo;
         private Dictionary<MenuItem, string> weaponComponents;
 
         #region Create Menu
@@ -36,6 +37,7 @@ namespace vMenuClient.menus
         {
             // Setup weapon dictionaries.
             weaponInfo = new Dictionary<Menu, ValidWeapon>();
+            addonWeaponInfo = new Dictionary<Menu, ValidAddonWeapon>();
             weaponComponents = new Dictionary<MenuItem, string>();
 
             #region create main weapon options menu and add items
@@ -81,49 +83,191 @@ namespace vMenuClient.menus
             #region addonweapons submenu
             var addonWeaponsBtn = new MenuItem("Addon Weapons", "Equip / remove addon weapons available on this server.");
             var addonWeaponsMenu = new Menu("Addon Weapons", "Equip/Remove Addon Weapons");
+            MenuController.AddSubmenu(menu, addonWeaponsMenu);
+            #endregion
+
+            #region addonweapons buttons
+            addonWeaponsBtn.Label = "→→→";
             menu.AddMenuItem(addonWeaponsBtn);
+            MenuController.BindMenuItem(menu, addonWeaponsMenu, addonWeaponsBtn);
+            #endregion
 
             #region manage creating and accessing addon weapons menu
-            if (IsAllowed(Permission.WPSpawn) && AddonWeapons != null && AddonWeapons.Count > 0)
+            foreach (var addonWeapon in ValidAddonWeapons.AddonWeaponsList)
             {
-                MenuController.BindMenuItem(menu, addonWeaponsMenu, addonWeaponsBtn);
-                foreach (var weapon in AddonWeapons)
+                if (IsAllowed(Permission.WPSpawn) && !string.IsNullOrEmpty(addonWeapon.Name) && AddonWeapons.Count > 0)
                 {
-                    var name = weapon.Key.ToString();
-                    var model = weapon.Value;
-                    var item = new MenuItem(name, $"Click to add/remove this weapon ({name}) to/from your inventory.");
-                    addonWeaponsMenu.AddMenuItem(item);
-                    if (!IsWeaponValid(model))
+                    var addonWeaponMenu = new Menu("Weapon Options", addonWeapon.Name)
+                    #region Create menu for this weapon and add buttons
                     {
-                        item.Enabled = false;
-                        item.LeftIcon = MenuItem.Icon.LOCK;
-                        item.Description = "This model is not available. Please ask the server owner to verify it's being streamed correctly.";
-                    }
-                }
-                addonWeaponsMenu.OnItemSelect += (sender, item, index) =>
-                {
-                    var weapon = AddonWeapons.ElementAt(index);
-                    if (HasPedGotWeapon(Game.PlayerPed.Handle, weapon.Value, false))
+                        ShowWeaponStatsPanel = true
+                    };
+                    var stats = new Game.WeaponHudStats();
+                    Game.GetWeaponHudStats(addonWeapon.Hash, ref stats);
+                    addonWeaponMenu.SetWeaponStats(stats.hudDamage / 100f, stats.hudSpeed / 100f, stats.hudAccuracy / 100f, stats.hudRange / 100f);
+                    var addonWeaponItem = new MenuItem(addonWeapon.Name, $"Open the options for ~y~{addonWeapon.Name}~s~.")
                     {
-                        RemoveWeaponFromPed(Game.PlayerPed.Handle, weapon.Value);
+                        Label = "→→→",
+                        LeftIcon = MenuItem.Icon.GUN,
+                        ItemData = stats
+                    };
+
+                    addonWeaponInfo.Add(addonWeaponMenu, addonWeapon);
+
+                    var getOrRemoveWeapon = new MenuItem("Equip/Remove Weapon", "Add or remove this weapon to/form your inventory.")
+                    {
+                        LeftIcon = MenuItem.Icon.GUN
+                    };
+                    addonWeaponMenu.AddMenuItem(getOrRemoveWeapon);
+
+
+                    var fillAmmo = new MenuItem("Re-fill Ammo", "Get max ammo for this weapon.")
+                    {
+                        LeftIcon = MenuItem.Icon.AMMO
+                    };
+                    addonWeaponMenu.AddMenuItem(fillAmmo);
+
+                    var tints = new List<string>();
+                    if (addonWeapon.Name.Contains(" Mk II"))
+                    {
+                        foreach (var tint in ValidWeapons.WeaponTintsMkII)
+                        {
+                            tints.Add(tint.Key);
+                        }
                     }
                     else
                     {
-                        var maxAmmo = 200;
-                        GetMaxAmmo(Game.PlayerPed.Handle, weapon.Value, ref maxAmmo);
-                        GiveWeaponToPed(Game.PlayerPed.Handle, weapon.Value, maxAmmo, false, true);
+                        foreach (var tint in ValidWeapons.WeaponTints)
+                        {
+                            tints.Add(tint.Key);
+                        }
                     }
-                };
-                addonWeaponsBtn.Label = "→→→";
-            }
-            else
-            {
-                addonWeaponsBtn.LeftIcon = MenuItem.Icon.LOCK;
-                addonWeaponsBtn.Enabled = false;
-                addonWeaponsBtn.Description = "This option is not available on this server because you don't have permission to use it, or it is not setup correctly.";
+
+                    var weaponTints = new MenuListItem("Tints", tints, 0, "Select a tint for your weapon.");
+                    addonWeaponMenu.AddMenuItem(weaponTints);
+                    #endregion
+
+                    #region Handle weapon specific list changes
+                    addonWeaponMenu.OnListIndexChange += (sender, item, oldIndex, newIndex, itemIndex) =>
+                    {
+                        if (item == weaponTints)
+                        {
+                            if (HasPedGotWeapon(Game.PlayerPed.Handle, addonWeaponInfo[sender].Hash, false))
+                            {
+                                SetPedWeaponTintIndex(Game.PlayerPed.Handle, addonWeaponInfo[sender].Hash, newIndex);
+                            }
+                            else
+                            {
+                                Notify.Error("You need to get the weapon first!");
+                            }
+                        }
+                    };
+                    #endregion
+
+                    #region Handle weapon specific button presses
+                    addonWeaponMenu.OnItemSelect += (sender, item, index) =>
+                    {
+                        var info = addonWeaponInfo[sender];
+                        var hash = info.Hash;
+                        SetCurrentPedWeapon(Game.PlayerPed.Handle, hash, true);
+                        if (item == getOrRemoveWeapon)
+                        {
+                            if (HasPedGotWeapon(Game.PlayerPed.Handle, hash, false))
+                            {
+                                RemoveWeaponFromPed(Game.PlayerPed.Handle, hash);
+                                Subtitle.Custom("Weapon removed.");
+                            }
+                            else
+                            {
+                                var ammo = 255;
+                                GetMaxAmmo(Game.PlayerPed.Handle, hash, ref ammo);
+                                GiveWeaponToPed(Game.PlayerPed.Handle, hash, ammo, false, true);
+                                Subtitle.Custom("Weapon added.");
+                            }
+                        }
+                        else if (item == fillAmmo)
+                        {
+                            if (HasPedGotWeapon(Game.PlayerPed.Handle, hash, false))
+                            {
+                                var ammo = 900;
+                                GetMaxAmmo(Game.PlayerPed.Handle, hash, ref ammo);
+                                SetPedAmmo(Game.PlayerPed.Handle, hash, ammo);
+                            }
+                            else
+                            {
+                                Notify.Error("You need to get the weapon first before re-filling ammo!");
+                            }
+                        }
+                    };
+                    #endregion
+
+                    #region load components
+                    if (addonWeapon.Components != null)
+                    {
+                        if (addonWeapon.Components.Count > 0)
+                        {
+                            foreach (var comp in addonWeapon.Components)
+                            {
+                                //Log($"{weapon.Name} : {comp.Key}");
+                                var compItem = new MenuItem(comp.Key, "Click to equip or remove this component.");
+                                weaponComponents.Add(compItem, comp.Key);
+                                addonWeaponMenu.AddMenuItem(compItem);
+
+                                #region Handle component button presses
+                                addonWeaponMenu.OnItemSelect += (sender, item, index) =>
+                                {
+                                    if (item == compItem)
+                                    {
+                                        var addonWeapon = addonWeaponInfo[sender];
+                                        var componentHash = addonWeapon.Components[weaponComponents[item]];
+                                        if (HasPedGotWeapon(Game.PlayerPed.Handle, addonWeapon.Hash, false))
+                                        {
+                                            SetCurrentPedWeapon(Game.PlayerPed.Handle, addonWeapon.Hash, true);
+                                            if (HasPedGotWeaponComponent(Game.PlayerPed.Handle, addonWeapon.Hash, componentHash))
+                                            {
+                                                RemoveWeaponComponentFromPed(Game.PlayerPed.Handle, addonWeapon.Hash, componentHash);
+                                                Subtitle.Custom("Component removed.");
+                                            }
+                                            else
+                                            {
+                                                var ammo = GetAmmoInPedWeapon(Game.PlayerPed.Handle, addonWeapon.Hash);
+                                                var clipAmmo = GetMaxAmmoInClip(Game.PlayerPed.Handle, addonWeapon.Hash, false);
+                                                GetAmmoInClip(Game.PlayerPed.Handle, addonWeapon.Hash, ref clipAmmo);
+                                                GiveWeaponComponentToPed(Game.PlayerPed.Handle, addonWeapon.Hash, componentHash);
+                                                SetAmmoInClip(Game.PlayerPed.Handle, addonWeapon.Hash, clipAmmo);
+                                                SetPedAmmo(Game.PlayerPed.Handle, addonWeapon.Hash, ammo);
+                                                Subtitle.Custom("Component equiped.");
+                                            }
+                                        }
+                                        else
+                                        {
+                                            Notify.Error("You need to get the weapon first before you can modify it.");
+                                        }
+                                    }
+                                };
+                                #endregion
+                            }
+                        }
+                    }
+                    #endregion
+
+                    // refresh and add to menu.
+                    addonWeaponMenu.RefreshIndex();
+
+                    MenuController.AddSubmenu(addonWeaponsMenu, addonWeaponMenu);
+                    MenuController.BindMenuItem(addonWeaponsMenu, addonWeaponMenu, addonWeaponItem);
+                    addonWeaponsMenu.AddMenuItem(addonWeaponItem);
+                }
             }
             #endregion
-            addonWeaponsMenu.RefreshIndex();
+
+            #region Disable submenu if category is not allowed.
+            if (addonWeaponsMenu.Size == 0)
+            {
+                addonWeaponsBtn.LeftIcon = MenuItem.Icon.LOCK;
+                addonWeaponsBtn.Description = "This option is not available on this server because you don't have permission to use it, or it is not setup correctly.";
+                addonWeaponsBtn.Enabled = false;
+            }
             #endregion
 
             #region parachute options menu
@@ -652,6 +796,15 @@ namespace vMenuClient.menus
                             SetPedAmmo(Game.PlayerPed.Handle, vw.Hash, ammo);
                         }
                     }
+                    foreach (var avw in ValidAddonWeapons.AddonWeaponsList)
+                    {
+                        GiveWeaponToPed(Game.PlayerPed.Handle, avw.Hash, avw.GetMaxAmmo, false, true);
+                        var ammoInClip = GetMaxAmmoInClip(Game.PlayerPed.Handle, avw.Hash, false);
+                        SetAmmoInClip(Game.PlayerPed.Handle, avw.Hash, ammoInClip);
+                        var ammo = 0;
+                        GetMaxAmmo(Game.PlayerPed.Handle, avw.Hash, ref ammo);
+                        SetPedAmmo(Game.PlayerPed.Handle, avw.Hash, ammo);
+                    }
 
                     SetCurrentPedWeapon(Game.PlayerPed.Handle, (uint)GetHashKey("weapon_unarmed"), true);
                 }
@@ -674,6 +827,17 @@ namespace vMenuClient.menus
                             var ammo = 0;
                             GetMaxAmmo(Game.PlayerPed.Handle, vw.Hash, ref ammo);
                             SetPedAmmo(Game.PlayerPed.Handle, vw.Hash, ammo);
+                        }
+                    }
+                    foreach (var avw in ValidAddonWeapons.AddonWeaponsList)
+                    {
+                        if (HasPedGotWeapon(Game.PlayerPed.Handle, avw.Hash, false))
+                        {
+                            var ammoInClip = GetMaxAmmoInClip(Game.PlayerPed.Handle, avw.Hash, false);
+                            SetAmmoInClip(Game.PlayerPed.Handle, avw.Hash, ammoInClip);
+                            var ammo = 0;
+                            GetMaxAmmo(Game.PlayerPed.Handle, avw.Hash, ref ammo);
+                            SetPedAmmo(Game.PlayerPed.Handle, avw.Hash, ammo);
                         }
                     }
                 }
@@ -721,6 +885,7 @@ namespace vMenuClient.menus
             melee.OnIndexChange += (sender, oldItem, newItem, oldIndex, newIndex) => { OnIndexChange(sender, newItem); };
             heavy.OnIndexChange += (sender, oldItem, newItem, oldIndex, newIndex) => { OnIndexChange(sender, newItem); };
             snipers.OnIndexChange += (sender, oldItem, newItem, oldIndex, newIndex) => { OnIndexChange(sender, newItem); };
+            addonWeaponsMenu.OnIndexChange += (sender, oldItem, newItem, oldIndex, newIndex) => { OnIndexChange(sender, newItem); };
 
             handGuns.OnMenuOpen += (sender) => { OnIndexChange(sender, sender.GetCurrentMenuItem()); };
             rifles.OnMenuOpen += (sender) => { OnIndexChange(sender, sender.GetCurrentMenuItem()); };
@@ -730,6 +895,7 @@ namespace vMenuClient.menus
             melee.OnMenuOpen += (sender) => { OnIndexChange(sender, sender.GetCurrentMenuItem()); };
             heavy.OnMenuOpen += (sender) => { OnIndexChange(sender, sender.GetCurrentMenuItem()); };
             snipers.OnMenuOpen += (sender) => { OnIndexChange(sender, sender.GetCurrentMenuItem()); };
+            addonWeaponsMenu.OnMenuOpen += (sender) => { OnIndexChange(sender, sender.GetCurrentMenuItem()); };
         }
 
 


### PR DESCRIPTION
An (inelegant) solution to https://github.com/TomGrobbe/vMenu/issues/418.

Addon Weapons can now use the Weapon Options Menu to allow for components, tints, individual refilling of ammo, etc just like vanilla weapons.