### PR TITLE
Update WeaponOptions.cs

### DIFF
--- a/vMenu/menus/WeaponOptions.cs
+++ b/vMenu/menus/WeaponOptions.cs
@@ -130,7 +130,7 @@ namespace vMenuClient.menus
                     addonWeaponMenu.AddMenuItem(fillAmmo);
 
                     var tints = new List<string>();
-                    if (addonWeapon.Name.Contains(" Mk II"))
+                    if (addonWeapon.Name.Contains(" Mk II") || addonWeapon.SpawnName.Contains("MK_II"))
                     {
                         foreach (var tint in ValidWeapons.WeaponTintsMkII)
                         {


### PR DESCRIPTION
Enables addon MK2 weapons to use MK2 tints without relying on AddTextEntry or AddTextEntryByHash (which have proven unreliable in testing)