### PR TITLE
Add new content from Money Fronts DLC (mp2025_01)

### DIFF
--- a/vMenu/data/PedModels.cs
+++ b/vMenu/data/PedModels.cs
@@ -43,6 +43,7 @@ namespace vMenuClient.data
             (uint)GetHashKey("a_c_retriever"),
             (uint)GetHashKey("a_c_rhesus"),
             (uint)GetHashKey("a_c_rottweiler"),
+            (uint)GetHashKey("a_c_rottweiler_02"), // mp2025_01
             (uint)GetHashKey("a_c_seagull"),
             (uint)GetHashKey("a_c_sharkhammer"),
             (uint)GetHashKey("a_c_sharktiger"),

--- a/vMenu/data/VehicleData.cs
+++ b/vMenu/data/VehicleData.cs
@@ -384,6 +384,8 @@ namespace vMenuClient.data
                 "COGNOSCENTI",
                 "COGNOSCENTI2",
                 "DEITY", // THE CONTRACT (MPSECURITY) DLC - Requires b2545
+                "DRIFTCHAVOSV6", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
+                "DRIFTHARDY", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "DRIFTVORSCHLAG", // BOTTOM DOLLAR BOUNTIES (MP2024_01) DLC - Requires b3258
                 "EMPEROR",
                 "EMPEROR2",
@@ -391,10 +393,12 @@ namespace vMenuClient.data
                 "FUGITIVE",
                 "GLENDALE",
                 "GLENDALE2", // SUMMER SPECIAL (MPSUM) DLC - Requires b2060
+                "HARDY", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "IMPALER5", // CHOP SHOP (MP2023_02) DLC - Requires b3095
                 "INGOT",
                 "INTRUDER",
                 "LIMO2",
+                "MINIMUS", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "PREMIER",
                 "PRIMO",
                 "PRIMO2",
@@ -440,6 +444,7 @@ namespace vMenuClient.data
                 "DORADO", // CHOP SHOP (MP2023_02) DLC - Requires b3095
                 "DUBSTA",
                 "DUBSTA2",
+                "EVERON3", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "FQ2",
                 "GRANGER",
                 "GRANGER2", // THE CONTRACT (MPSECURITY) DLC - Requires b2545
@@ -465,6 +470,7 @@ namespace vMenuClient.data
                 "SQUADDIE", // CAYO PERICO (MPHEIST4) DLC - Requires b2189
                 "TOROS",
                 "VIVANITE", // CHOP SHOP (MP2023_02) DLC - Requires b3095
+                "WOODLANDER", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "XLS",
                 "XLS2",
             };
@@ -520,6 +526,8 @@ namespace vMenuClient.data
                 "DOMINATOR7", // LS TUNERS (MPTUNER) DLC - Requires b2372
                 "DOMINATOR8", // LS TUNERS (MPTUNER) DLC - Requires b2372
                 "DOMINATOR9", // CHOP SHOP (MP2023_02) DLC - Requires b3095
+                "DRIFTDOMINATOR10", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
+                "DRIFTGAUNTLET4", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "DRIFTYOSEMITE", // CHOP SHOP (MP2023_02) DLC - Requires b3095
                 "DUKES",
                 "DUKES2",
@@ -573,6 +581,7 @@ namespace vMenuClient.data
                 "TAHOMA", // DRUG WARS (MPCHRISTMAS3) DLC - Requires b2802
                 "TAMPA",
                 "TAMPA3",
+                "TAMPA4", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "TULIP",
                 "TULIP2", // DRUG WARS (MPCHRISTMAS3) DLC - Requires b2802
                 "VAMOS",
@@ -599,6 +608,7 @@ namespace vMenuClient.data
                 "CASCO",
                 "CHEBUREK",
                 "CHEETAH2",
+                "CHEETAH3", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "COQUETTE2",
                 "COQUETTE5", // BOTTOM DOLLAR BOUNTIES (MP2024_01) DLC - Requires b3258
                 "DELUXO",
@@ -731,6 +741,7 @@ namespace vMenuClient.data
                 "RAIDEN",
                 "RAPIDGT",
                 "RAPIDGT2",
+                "RAPIDGT4", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "RAPTOR",
                 "REMUS", // LS TUNERS (MPTUNER) DLC - Requires b2372
                 "REVOLTER",
@@ -744,6 +755,7 @@ namespace vMenuClient.data
                 "SCHWARZER",
                 "SENTINEL3",
                 "SENTINEL4", // CRIMINAL ENTERPRISES (MPSUM2) DLC - Requires b2699
+                "SENTINEL5", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "SEVEN70",
                 "SM722", // CRIMINAL ENTERPRISES (MPSUM2) DLC - Requires b2699
                 "SPECTER",
@@ -807,6 +819,7 @@ namespace vMenuClient.data
                 "SCRAMJET",
                 "SHEAVA", // ETR1
                 "SULTANRS",
+                "SUZUME", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "T20",
                 "TAIPAN",
                 "TEMPESTA",
@@ -918,6 +931,7 @@ namespace vMenuClient.data
                 "CARACARA2", // CASINO AND RESORT (MPVINEWOOD) DLC - Requires b2060
                 "DLOADER",
                 "DRAUGUR", // CRIMINAL ENTERPRISES (MPSUM2) DLC - Requires b2699
+                "DRIFTL352", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "DUBSTA3",
                 "DUNE",
                 "DUNE2",
@@ -934,6 +948,7 @@ namespace vMenuClient.data
                 "INSURGENT3",
                 "KALAHARI",
                 "KAMACHO",
+                "L352", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "MARSHALL",
                 "MENACER",
                 "MESA3",
@@ -975,6 +990,7 @@ namespace vMenuClient.data
                 "CUTTER",
                 "DUMP",
                 "FLATBED",
+                "FLATBED2", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "GUARDIAN",
                 "HANDLER",
                 "MIXER",
@@ -1162,6 +1178,7 @@ namespace vMenuClient.data
                 "HAVOK",
                 "HUNTER",
                 "MAVERICK",
+                "MAVERICK2", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "POLMAV",
                 "SAVAGE",
                 "SEASPARROW",
@@ -1268,6 +1285,7 @@ namespace vMenuClient.data
                 "POLICE4",
                 "POLICE5", // CHOP SHOP (MP2023_02) DLC - Requires b3095
                 "POLICEB",
+                "POLICEB2", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "POLICEOLD1",
                 "POLICEOLD2",
                 "POLICET",
@@ -1331,6 +1349,7 @@ namespace vMenuClient.data
                 "POUNDER2",
                 "STOCKADE",
                 "STOCKADE3",
+                "STOCKADE4", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "TERBYTE",
             };
             #endregion

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -1462,6 +1462,7 @@ namespace vMenuClient.menus
             ["csb_abigail"] = "AbigailCutscene",
             ["csb_agatha"] = "AgathaCutscene", // mpvinewood
             ["csb_agent"] = "AgentCutscene",
+            ["csb_agent14_02"] = "Agent1402Cutscene", // mp2025_01
             ["csb_alan"] = "AlanCutscene",
             ["csb_anita"] = "AnitaCutscene",
             ["csb_anton"] = "AntonCutscene",
@@ -1552,6 +1553,7 @@ namespace vMenuClient.menus
             ["csb_porndudes"] = "PornDudesCutscene",
             ["csb_prologuedriver"] = "PrologueDriverCutscene",
             ["csb_prolsec"] = "PrologueSec01Cutscene",
+            ["csb_rafdeangelis"] = "RafDeAngelisCutscene", // mp2025_01
             ["csb_ramp_gang"] = "RampGangCutscene",
             ["csb_ramp_hic"] = "RampHicCutscene",
             ["csb_ramp_hipster"] = "RampHipsterCutscene",
@@ -1579,14 +1581,17 @@ namespace vMenuClient.menus
             ["csb_undercover"] = "UndercoverCutscene",
             ["csb_vagos_leader"] = "VagosLeaderCutscene", // mpsecurity
             ["csb_vagspeak"] = "VagSpeakCutscene",
+            ["csb_valentina"] = "ValentinaCutscene", // mp2025_01
             ["csb_vernon"] = "VernonCutscene", // mpsecurity
             ["csb_vincent"] = "VincentCutscene", // mpvinewood
             ["csb_vincent_2"] = "Vincent2Cutscene", // mpheist3
             ["csb_vincent_4"] = "Vincent4Cutscene", // mp2023_02
             ["csb_yusufamir"] = "YusufAmirCuscene", // mp2023_02
+            ["csb_weiss"] = "WeissCutscene", // mp2025_01
             ["csb_wendy"] = "WendyCutscene", // mpheist3
             ["g_f_importexport_01"] = "ImportExport01GF",
             ["g_f_m_fooliganz_01"] = "Fooliganz01GFM", // mpchristmas3
+            ["g_f_m_undeadmage"] = "UndeadMageGFM", // mp2025_01
             ["g_f_y_ballas_01"] = "Ballas01GFY",
             ["g_f_y_families_01"] = "Families01GFY",
             ["g_f_y_lost_01"] = "Lost01GFY",
@@ -1617,6 +1622,8 @@ namespace vMenuClient.menus
             ["g_m_m_zombie_01"] = "Zombie01GMM", // mp2024_01
             ["g_m_m_zombie_02"] = "Zombie02GMM", // mp2024_01
             ["g_m_m_zombie_03"] = "Zombie03GMM", // mp2024_01
+            ["g_m_m_zombie_04"] = "Zombie04GMM", // mp2025_01
+            ["g_m_m_zombie_05"] = "Zombie05GMM", // mp2025_01
             ["g_m_y_armgoon_02"] = "ArmGoon02GMY",
             ["g_m_y_azteca_01"] = "Azteca01GMY",
             ["g_m_y_ballaeast_01"] = "BallaEast01GMY",
@@ -1650,6 +1657,7 @@ namespace vMenuClient.menus
             ["ig_acidlabcook"] = "AcidLabCook", // mpchristmas3
             ["ig_agatha"] = "Agatha", // mpvinewood
             ["ig_agent"] = "Agent",
+            ["ig_agent14_02"] = "Agent1402", // mp2025_01
             ["ig_agent_02"] = "Agent02", //mpsum2
             ["ig_ahronward"] = "AhronWard", // mp2023_02
             ["ig_amandatownley"] = "AmandaTownley",
@@ -1737,6 +1745,7 @@ namespace vMenuClient.menus
             ["ig_guadalope"] = "Guadalope", // mp2024_02
             ["ig_gunvanseller"] = "GunVanSeller", // mpchristmas3
             ["ig_gustavo"] = "Gustavo", // mpheist4
+            ["ig_gustavo_02"] = "Gustavo02", // mp2025_01
             ["ig_hao"] = "Hao",
             ["ig_hao_02"] = "Hao02", // patchday26ng
             ["ig_helmsmanpavel"] = "HelmsmanPavel", // mpheist4
@@ -1790,10 +1799,12 @@ namespace vMenuClient.menus
             ["ig_lifeinvad_02"] = "Lifeinvad02",
             ["ig_lildee"] = "LilDee", // mptuner
             ["ig_luchadora"] = "Luchadora", // mpchristmas3
+            ["ig_madrazodriver_01"] = "MadrazoDriver01", // mp2025_01
             ["ig_magenta"] = "Magenta",
             ["ig_malc"] = "Malc",
             ["ig_manuel"] = "Manuel",
             ["ig_marnie"] = "Marnie",
+            ["ig_martinmadrazo_02"] = "MartinMadrazo02", // mp2025_01
             ["ig_maryann"] = "MaryAnn",
             ["ig_mason_duggan"] = "MasonDuggan", // mpsum2
             ["ig_maude"] = "Maude",
@@ -1838,6 +1849,7 @@ namespace vMenuClient.menus
             ["ig_popov"] = "Popov",
             ["ig_priest"] = "Priest",
             ["ig_prolsec_02"] = "PrologueSec02",
+            ["ig_rafdeangelis"] = "RafDeAngelis", // mp2025_01
             ["ig_ramp_gang"] = "RampGang",
             ["ig_ramp_hic"] = "RampHic",
             ["ig_ramp_hipster"] = "RampHipster",
@@ -1852,6 +1864,7 @@ namespace vMenuClient.menus
             ["ig_security_a"] = "SecurityA", // mpsecurity
             ["ig_sessanta"] = "Sessanta", // mptuner
             ["ig_siemonyetarian"] = "SiemonYetarian",
+            ["ig_skeleton_01"] = "Skeleton01", // mp2025_01
             ["ig_sol"] = "Sol",
             ["ig_solomon"] = "Solomon",
             ["ig_soundeng_00"] = "SoundEng00", // mpsecurity
@@ -1880,16 +1893,19 @@ namespace vMenuClient.menus
             ["ig_tylerdix_02"] = "TylerDixon02",
             ["ig_vagos_leader"] = "VagosLeader", // mpsecurity
             ["ig_vagspeak"] = "VagSpeak",
+            ["ig_valentina"] = "Valentina", // mp2025_01
             ["ig_vernon"] = "Vernon", // mpsecurity
             ["ig_vincent"] = "Vincent", // mpvinewood
             ["ig_vincent_2"] = "Vincent2", // mpheist3
             ["ig_vincent_3"] = "Vincent3", // mpsecurity
             ["ig_vincent_4"] = "Vincent4", // mp2023_02
             ["ig_wade"] = "Wade",
+            ["ig_weiss"] = "Weiss", // mp2025_01
             ["ig_warehouseboss"] = "WarehouseBoss", // mpsum2
             ["ig_wendy"] = "Wendy", // mpheist3
             ["ig_yusufamir"] = "YusufAmir", // mp2023_02
             ["ig_zimbor"] = "Zimbor",
+            ["ig_zombie_dj_01"] = "ZombieDJ01", // mp2025_01
             ["mp_f_bennymech_01"] = "BennyMechanic01",
             ["mp_f_boatstaff_01"] = "MBoatStaff01",
             ["mp_f_cardesign_01"] = "CarDesign01",


### PR DESCRIPTION
Adds new ped models and vehicles introduced in the Money Fronts (MP2025_01) DLC to the lists.

This ensures they are available in the vMenu client, assuming the server is running a compatible game build (b3570 or later).