### PR TITLE
Clothing collections

### DIFF
--- a/vMenu/MpPedDataManager.cs
+++ b/vMenu/MpPedDataManager.cs
@@ -8,12 +8,32 @@ namespace vMenuClient
     {
         public struct DrawableVariations
         {
-            public Dictionary<int, KeyValuePair<int, int>> clothes;
+            public Dictionary<int, KeyValuePair<int, int>> clothes; // legacy
+            public Dictionary<int, CharacterClothingData> clothesWithCollection; // new
+        }
+        public class CharacterClothingData
+        {
+            public int ComponentIndex { get; set; }
+            public int Drawable { get; set; }
+            public int Texture { get; set; }
+            public string Collection { get; set; }
+        }
+        public static class ClothingCollections
+        {
+            public const string BaseGame = "base";
         }
 
         public struct PropVariations
         {
-            public Dictionary<int, KeyValuePair<int, int>> props;
+            public Dictionary<int, KeyValuePair<int, int>> props; // legacy
+            public Dictionary<int, CharacterPropData> propsWithCollection; // new
+        }
+        public class CharacterPropData
+        {
+            public int PropIndex { get; set; }
+            public int Drawable { get; set; }
+            public int Texture { get; set; }
+            public string Collection { get; set; }
         }
 
         public struct FaceShapeFeatures
@@ -109,6 +129,8 @@ namespace vMenuClient
             public PedAppearance PedAppearance;
             public PedTattoos PedTatttoos;
             public PedFacePaints PedFacePaints;
+            public Dictionary<int, CharacterClothingData> clothesWithCollection;
+            public Dictionary<int, CharacterPropData> propsWithCollection;
             public bool IsMale;
             public uint ModelHash;
             public string SaveName;

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -14,6 +15,8 @@ using vMenuClient.data;
 using static CitizenFX.Core.Native.API;
 using static vMenuClient.CommonFunctions;
 using static vMenuClient.MpPedDataManager;
+using static vMenuClient.MpPedDataManager.DrawableVariations;
+using static vMenuClient.MpPedDataManager.PropVariations;
 using static vMenuShared.ConfigManager;
 
 namespace vMenuClient.menus
@@ -145,7 +148,9 @@ namespace vMenuClient.menus
             {
                 currentCharacter = new MultiplayerPedData();
                 currentCharacter.DrawableVariations.clothes = new Dictionary<int, KeyValuePair<int, int>>();
+                currentCharacter.DrawableVariations.clothesWithCollection = new Dictionary<int, CharacterClothingData>();
                 currentCharacter.PropVariations.props = new Dictionary<int, KeyValuePair<int, int>>();
+                currentCharacter.PropVariations.propsWithCollection = new Dictionary<int, CharacterPropData>();
                 currentCharacter.PedHeadBlendData = Game.PlayerPed.GetHeadBlendData();
                 currentCharacter.Version = 1;
                 currentCharacter.ModelHash = male ? (uint)GetHashKey("mp_m_freemode_01") : (uint)GetHashKey("mp_f_freemode_01");
@@ -154,7 +159,9 @@ namespace vMenuClient.menus
                 SetPlayerClothing();
             }
             currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
+            currentCharacter.DrawableVariations.clothesWithCollection ??= new Dictionary<int, CharacterClothingData>();
             currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
+            currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
 
             // Set the facial expression to default in case it doesn't exist yet, or keep the current one if it does.
             currentCharacter.FacialExpression ??= facial_expressions[0];
@@ -486,22 +493,52 @@ namespace vMenuClient.menus
 
             #region clothing options menu
             var clothingCategoryNames = new string[12] { "Unused (head)", "Masks", "Unused (hair)", "Upper Body", "Lower Body", "Bags & Parachutes", "Shoes", "Scarfs & Chains", "Shirt & Accessory", "Body Armor & Accessory 2", "Badges & Logos", "Shirt Overlay & Jackets" };
+
             for (var i = 0; i < 12; i++)
             {
                 if (i is not 0 and not 2)
                 {
-                    var currentVariationIndex = editPed && currentCharacter.DrawableVariations.clothes.ContainsKey(i) ? currentCharacter.DrawableVariations.clothes[i].Key : GetPedDrawableVariation(Game.PlayerPed.Handle, i);
-                    var currentVariationTextureIndex = editPed && currentCharacter.DrawableVariations.clothes.ContainsKey(i) ? currentCharacter.DrawableVariations.clothes[i].Value : GetPedTextureVariation(Game.PlayerPed.Handle, i);
+                    int currentVariationIndex;
+                    int currentVariationTextureIndex;
+
+                    if (editPed)
+                    {
+                        // New format
+                        if (currentCharacter.DrawableVariations.clothesWithCollection != null && currentCharacter.DrawableVariations.clothesWithCollection.TryGetValue(i, out var cloth))
+                        {
+                            if (cloth.Collection == "base")
+                                currentVariationIndex = cloth.Drawable; // use local index for base
+                            else
+                                currentVariationIndex = GetPedDrawableGlobalIndexFromCollection(Game.PlayerPed.Handle, i, cloth.Collection, cloth.Drawable);
+
+                            currentVariationTextureIndex = cloth.Texture;
+                        }
+                        // Legacy fallback
+                        else if (currentCharacter.DrawableVariations.clothes != null && currentCharacter.DrawableVariations.clothes.TryGetValue(i, out var legacyCloth))
+                        {
+                            currentVariationIndex = legacyCloth.Key;
+                            currentVariationTextureIndex = legacyCloth.Value;
+                        }
+                        else
+                        {
+                            currentVariationIndex = GetPedDrawableVariation(Game.PlayerPed.Handle, i);
+                            currentVariationTextureIndex = GetPedTextureVariation(Game.PlayerPed.Handle, i);
+                        }
+                    }
+                    else
+                    {
+                        currentVariationIndex = GetPedDrawableVariation(Game.PlayerPed.Handle, i);
+                        currentVariationTextureIndex = GetPedTextureVariation(Game.PlayerPed.Handle, i);
+                    }
 
                     var maxDrawables = GetNumberOfPedDrawableVariations(Game.PlayerPed.Handle, i);
+                    var maxTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, i, currentVariationIndex);
 
                     var items = new List<string>();
                     for (var x = 0; x < maxDrawables; x++)
                     {
                         items.Add($"Drawable #{x} (of {maxDrawables})");
                     }
-
-                    var maxTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, i, currentVariationIndex);
 
                     var listItem = new MenuListItem(clothingCategoryNames[i], items, currentVariationIndex, $"Select a drawable using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{currentVariationTextureIndex + 1} (of {maxTextures}).");
                     clothesMenu.AddMenuItem(listItem);
@@ -511,26 +548,53 @@ namespace vMenuClient.menus
 
             #region props options menu
             var propNames = new string[5] { "Hats & Helmets", "Glasses", "Misc Props", "Watches", "Bracelets" };
+
             for (var x = 0; x < 5; x++)
             {
-                var propId = x;
-                if (x > 2)
+                var propId = x > 2 ? x + 3 : x;
+
+                int currentProp;
+                int currentPropTexture;
+
+                if (editPed)
                 {
-                    propId += 3;
+                    // New format
+                    if (currentCharacter.PropVariations.propsWithCollection != null && currentCharacter.PropVariations.propsWithCollection.TryGetValue(propId, out var prop))
+                    {
+                        if (prop.Collection == "base")
+                            currentProp = prop.Drawable;
+                        else
+                            currentProp = GetPedPropGlobalIndexFromCollection(Game.PlayerPed.Handle, propId, prop.Collection, prop.Drawable);
+
+                        currentPropTexture = prop.Texture;
+                    }
+                    // Legacy fallback
+                    else if (currentCharacter.PropVariations.props != null && currentCharacter.PropVariations.props.TryGetValue(propId, out var legacyProp))
+                    {
+                        currentProp = legacyProp.Key;
+                        currentPropTexture = legacyProp.Value;
+                    }
+                    else
+                    {
+                        currentProp = GetPedPropIndex(Game.PlayerPed.Handle, propId);
+                        currentPropTexture = GetPedPropTextureIndex(Game.PlayerPed.Handle, propId);
+                    }
+                }
+                else
+                {
+                    currentProp = GetPedPropIndex(Game.PlayerPed.Handle, propId);
+                    currentPropTexture = GetPedPropTextureIndex(Game.PlayerPed.Handle, propId);
                 }
 
-                var currentProp = editPed && currentCharacter.PropVariations.props.ContainsKey(propId) ? currentCharacter.PropVariations.props[propId].Key : GetPedPropIndex(Game.PlayerPed.Handle, propId);
-                var currentPropTexture = editPed && currentCharacter.PropVariations.props.ContainsKey(propId) ? currentCharacter.PropVariations.props[propId].Value : GetPedPropTextureIndex(Game.PlayerPed.Handle, propId);
-
                 var propsList = new List<string>();
-                for (var i = 0; i < GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propId); i++)
+                var maxProps = GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propId);
+                for (var i = 0; i < maxProps; i++)
                 {
-                    propsList.Add($"Prop #{i} (of {GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propId)})");
+                    propsList.Add($"Prop #{i} (of {maxProps})");
                 }
                 propsList.Add("No Prop");
 
-
-                if (GetPedPropIndex(Game.PlayerPed.Handle, propId) != -1)
+                if (currentProp != -1)
                 {
                     var maxPropTextures = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propId, currentProp);
                     var propListItem = new MenuListItem($"{propNames[x]}", propsList, currentProp, $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{currentPropTexture + 1} (of {maxPropTextures}).");
@@ -538,11 +602,9 @@ namespace vMenuClient.menus
                 }
                 else
                 {
-                    var propListItem = new MenuListItem($"{propNames[x]}", propsList, currentProp, "Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.");
+                    var propListItem = new MenuListItem($"{propNames[x]}", propsList, 0, "Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.");
                     propsMenu.AddMenuItem(propListItem);
                 }
-
-
             }
             #endregion
 
@@ -721,8 +783,13 @@ namespace vMenuClient.menus
         private async Task<bool> SavePed()
         {
             currentCharacter.PedHeadBlendData = Game.PlayerPed.GetHeadBlendData();
+            currentCharacter = ReplacePedDataClothing(currentCharacter);
             if (isEdidtingPed)
             {
+                // Ensure SaveName is set
+                if (string.IsNullOrEmpty(currentCharacter.SaveName))
+                    currentCharacter.SaveName = "mp_ped_" + selectedSavedCharacterManageName;
+
                 var json = JsonConvert.SerializeObject(currentCharacter);
                 if (StorageManager.SaveJsonData(currentCharacter.SaveName, json, true))
                 {
@@ -761,7 +828,6 @@ namespace vMenuClient.menus
                     }
                 }
             }
-
         }
 
         /// <summary>
@@ -1295,20 +1361,31 @@ namespace vMenuClient.menus
             #region clothes
             clothesMenu.OnListIndexChange += (_menu, listItem, oldSelectionIndex, newSelectionIndex, realIndex) =>
             {
-                var componentIndex = realIndex + 1;
+                int componentIndex = realIndex + 1;
                 if (realIndex > 0)
                 {
                     componentIndex += 1;
                 }
 
-                var textureIndex = GetPedTextureVariation(Game.PlayerPed.Handle, componentIndex);
-                var newTextureIndex = 0;
-                SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, newSelectionIndex, newTextureIndex, 0);
+                int newTextureIndex = 0;
+
+                SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, newSelectionIndex, newTextureIndex, 0);              
+
                 currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
-
-                var maxTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
-
                 currentCharacter.DrawableVariations.clothes[componentIndex] = new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
+
+                string collectionName = GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
+
+                currentCharacter.DrawableVariations.clothesWithCollection ??= new();              
+                currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] = new CharacterClothingData
+                {
+                    ComponentIndex = componentIndex,
+                    Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
+                    Texture = newTextureIndex,
+                    Collection = collectionName
+                };
+
+                int maxTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
                 listItem.Description = $"Select a drawable using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
             };
 
@@ -1320,14 +1397,27 @@ namespace vMenuClient.menus
                     componentIndex += 1;
                 }
 
-                var textureIndex = GetPedTextureVariation(Game.PlayerPed.Handle, componentIndex);
-                var newTextureIndex = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, listIndex) - 1 < textureIndex + 1 ? 0 : textureIndex + 1;
+                int textureIndex = GetPedTextureVariation(Game.PlayerPed.Handle, componentIndex);
+                int newTextureIndex = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, listIndex) - 1 < textureIndex + 1 ? 0 : textureIndex + 1;
+                
                 SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, listIndex, newTextureIndex, 0);
+
                 currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
-
-                var maxTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, listIndex);
-
                 currentCharacter.DrawableVariations.clothes[componentIndex] = new KeyValuePair<int, int>(listIndex, newTextureIndex);
+
+                string collectionName = GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex);
+                if (string.IsNullOrEmpty(collectionName)) collectionName = "base";
+
+                currentCharacter.DrawableVariations.clothesWithCollection ??= new Dictionary<int, CharacterClothingData>();
+                currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] = new CharacterClothingData
+                {
+                    ComponentIndex = componentIndex,
+                    Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, listIndex),
+                    Texture = newTextureIndex,
+                    Collection = collectionName
+                };
+
+                int maxTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, listIndex);
                 listItem.Description = $"Select a drawable using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
             };
             #endregion
@@ -1335,7 +1425,7 @@ namespace vMenuClient.menus
             #region props
             propsMenu.OnListIndexChange += (_menu, listItem, oldSelectionIndex, newSelectionIndex, realIndex) =>
             {
-                var propIndex = realIndex;
+                int propIndex = realIndex;
                 if (realIndex == 3)
                 {
                     propIndex = 6;
@@ -1344,28 +1434,56 @@ namespace vMenuClient.menus
                 {
                     propIndex = 7;
                 }
+                int textureIndex = 0;
 
-                var textureIndex = 0;
-                if (newSelectionIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
+                int maxDrawables = GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex);
+                bool isNoProp = newSelectionIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex);
+
+                currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
+                currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
+
+                if (isNoProp)
                 {
                     SetPedPropIndex(Game.PlayerPed.Handle, propIndex, -1, -1, false);
                     ClearPedProp(Game.PlayerPed.Handle, propIndex);
                     currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
                     currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(-1, -1);
-                    listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
+                    currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
+                    currentCharacter.PropVariations.propsWithCollection[propIndex] = new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable = -1,
+                        Texture = -1,
+                        Collection = "base"
+                    };
+
+                    listItem.Description = "Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
                 }
                 else
                 {
                     SetPedPropIndex(Game.PlayerPed.Handle, propIndex, newSelectionIndex, textureIndex, true);
                     currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
                     currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(newSelectionIndex, textureIndex);
+
+                    string collectionName = GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, newSelectionIndex);
+                    if (string.IsNullOrEmpty(collectionName)) collectionName = "base";
+
+                    currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
+                    currentCharacter.PropVariations.propsWithCollection[propIndex] = new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable = GetPedCollectionLocalIndexFromProp(Game.PlayerPed.Handle, propIndex, newSelectionIndex),
+                        Texture = textureIndex,
+                        Collection = collectionName
+                    };
+
                     if (GetPedPropIndex(Game.PlayerPed.Handle, propIndex) == -1)
                     {
                         listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
                     }
                     else
                     {
-                        var maxPropTextures = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, newSelectionIndex);
+                        int maxPropTextures = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, newSelectionIndex);
                         listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{textureIndex + 1} (of {maxPropTextures}).";
                     }
                 }
@@ -1383,14 +1501,22 @@ namespace vMenuClient.menus
                     propIndex = 7;
                 }
 
-                var textureIndex = GetPedPropTextureIndex(Game.PlayerPed.Handle, propIndex);
-                var newTextureIndex = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex) - 1 < textureIndex + 1 ? 0 : textureIndex + 1;
-                if (textureIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
+                int textureIndex = GetPedPropTextureIndex(Game.PlayerPed.Handle, propIndex);
+                int newTextureIndex = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex) - 1 < textureIndex + 1 ? 0 : textureIndex + 1;
+                if (listIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
                 {
                     SetPedPropIndex(Game.PlayerPed.Handle, propIndex, -1, -1, false);
                     ClearPedProp(Game.PlayerPed.Handle, propIndex);
                     currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
                     currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(-1, -1);
+                    currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
+                    currentCharacter.PropVariations.propsWithCollection[propIndex] = new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable = -1,
+                        Texture = -1,
+                        Collection = "base"
+                    };
                     listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
                 }
                 else
@@ -1398,6 +1524,18 @@ namespace vMenuClient.menus
                     SetPedPropIndex(Game.PlayerPed.Handle, propIndex, listIndex, newTextureIndex, true);
                     currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
                     currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(listIndex, newTextureIndex);
+
+                    string collectionName = GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, listIndex);
+                    if (string.IsNullOrEmpty(collectionName)) collectionName = "base";
+
+                    currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(listIndex, newTextureIndex);
+                    currentCharacter.PropVariations.propsWithCollection[propIndex] = new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable = GetPedCollectionLocalIndexFromProp(Game.PlayerPed.Handle, propIndex, listIndex),
+                        Texture = newTextureIndex,
+                        Collection = collectionName
+                    };
                     if (GetPedPropIndex(Game.PlayerPed.Handle, propIndex) == -1)
                     {
                         listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
@@ -2977,20 +3115,81 @@ namespace vMenuClient.menus
         {
             int handle = Game.PlayerPed.Handle;
 
-            // Drawables
+            // Init if null
+            character.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
+            character.DrawableVariations.clothesWithCollection ??= new Dictionary<int, CharacterClothingData>();
+            character.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
+            character.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
+
             for (int i = 0; i < 12; i++)
             {
-                int drawable = GetPedDrawableVariation(handle, i);
                 int texture = GetPedTextureVariation(handle, i);
+                string collectionName = GetPedDrawableVariationCollectionName(handle, i);
+
+                int drawable;
+                if (string.IsNullOrEmpty(collectionName) || collectionName == "base")
+                {
+                    drawable = GetPedDrawableVariation(handle, i);
+                    collectionName = "base";
+                }
+                else
+                {
+                    drawable = GetPedDrawableVariationCollectionLocalIndex(handle, i);
+                }
+
                 character.DrawableVariations.clothes[i] = new KeyValuePair<int, int>(drawable, texture);
+                character.DrawableVariations.clothesWithCollection[i] = new CharacterClothingData
+                {
+                    ComponentIndex = i,
+                    Drawable = drawable,
+                    Texture = texture,
+                    Collection = collectionName
+                };
             }
 
             for (int i = 0; i < 8; i++)
             {
-                int prop = GetPedPropIndex(handle, i);
                 int texture = GetPedPropTextureIndex(handle, i);
-                character.PropVariations.props[i] = new KeyValuePair<int, int>(prop, texture);
+                string collectionName = GetPedCollectionNameFromProp(handle, i, GetPedPropIndex(handle, i));
+
+
+                int drawable;
+                if (string.IsNullOrEmpty(collectionName) || collectionName == "base")
+                {
+                    drawable = GetPedPropIndex(handle, i);
+                    collectionName = "base";
+                }
+                else
+                {
+                    drawable = GetPedCollectionLocalIndexFromProp(handle, i, GetPedPropIndex(handle, i));
+                }
+
+
+                if (drawable == -1) // no prop at this index
+                {
+                    character.PropVariations.props[i] = new KeyValuePair<int, int>(-1, -1);
+                    character.PropVariations.propsWithCollection[i] = new CharacterPropData
+                    {
+                        PropIndex = i,
+                        Drawable = -1,
+                        Texture = -1,
+                        Collection = "base"
+                    };
+                    continue;
+                }
+
+                character.PropVariations.props[i] = new KeyValuePair<int, int>(drawable, texture);
+                character.PropVariations.propsWithCollection[i] = new CharacterPropData
+                {
+                    PropIndex = i,
+                    Drawable = drawable,
+                    Texture = texture,
+                    Collection = collectionName
+                };
             }
+
+            /*character.clothesWithCollection = character.DrawableVariations.clothesWithCollection;
+            character.propsWithCollection = character.PropVariations.propsWithCollection;*/
 
             return character;
         }
@@ -3182,24 +3381,57 @@ namespace vMenuClient.menus
             #endregion
 
             #region Clothing Data
-            if (character.DrawableVariations.clothes != null && character.DrawableVariations.clothes.Count > 0)
+            // Apply clothing (supports old KeyValuePair and new object structure)
+            if (character.DrawableVariations.clothesWithCollection != null && character.DrawableVariations.clothesWithCollection?.Count > 0)
             {
-                foreach (var cd in character.DrawableVariations.clothes)
+                foreach (var item in character.DrawableVariations.clothesWithCollection.Values)
                 {
-                    SetPedComponentVariation(pedHandle, cd.Key, cd.Value.Key, cd.Value.Value, 0);
+                    if (item.Collection == "base")
+                    {
+                        SetPedComponentVariation(pedHandle, item.ComponentIndex, item.Drawable, item.Texture, 0);
+                    }
+                    else
+                    {
+                        SetPedCollectionComponentVariation(pedHandle, item.ComponentIndex, item.Collection, item.Drawable, item.Texture, 0);
+                    }
+                }
+            }
+            else if (character.DrawableVariations.clothes != null && character.DrawableVariations.clothes.Count > 0)
+            {
+                foreach (var kvp in character.DrawableVariations.clothes)
+                {
+                    SetPedComponentVariation(pedHandle, kvp.Key, kvp.Value.Key, kvp.Value.Value, 0);
                 }
             }
             #endregion
 
             #region Props Data
-            if (character.PropVariations.props != null && character.PropVariations.props.Count > 0)
+            // Apply props (supports old KeyValuePair and new object structure)
+            if (character.PropVariations.propsWithCollection != null && character.PropVariations.propsWithCollection.Count > 0)
             {
-                foreach (var cd in character.PropVariations.props)
+                foreach (var item in character.PropVariations.propsWithCollection.Values)
                 {
-                    if (cd.Value.Key > -1)
+                    if (item.Drawable > -1)
                     {
-                        int textureIndex = cd.Value.Value > -1 ? cd.Value.Value : 0;
-                        SetPedPropIndex(pedHandle, cd.Key, cd.Value.Key, textureIndex, true);
+                        if (item.Collection == "base")
+                        {
+                            SetPedPropIndex(pedHandle, item.PropIndex, item.Drawable, item.Texture, true);
+                        }
+                        else
+                        {
+                            SetPedCollectionPropIndex(pedHandle, item.PropIndex, item.Collection, item.Drawable, item.Texture, true);
+                        }
+                    }
+                }
+            }
+            else if (character.PropVariations.props != null && character.PropVariations.props.Count > 0)
+            {
+                foreach (var kvp in character.PropVariations.props)
+                {
+                    if (kvp.Value.Key > -1)
+                    {
+                        int texture = kvp.Value.Value > -1 ? kvp.Value.Value : 0;
+                        SetPedPropIndex(pedHandle, kvp.Key, kvp.Value.Key, texture, true);
                     }
                 }
             }

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -3131,13 +3131,14 @@ namespace vMenuClient.menus
                 {
                     drawable = GetPedDrawableVariation(handle, i);
                     collectionName = "base";
+                    character.DrawableVariations.clothes[i] = new KeyValuePair<int, int>(drawable, texture);
                 }
                 else
                 {
                     drawable = GetPedDrawableVariationCollectionLocalIndex(handle, i);
+                    character.DrawableVariations.clothes[i] = new KeyValuePair<int, int>(GetPedDrawableGlobalIndexFromCollection(handle, i, collectionName, drawable), texture);
                 }
 
-                character.DrawableVariations.clothes[i] = new KeyValuePair<int, int>(drawable, texture);
                 character.DrawableVariations.clothesWithCollection[i] = new CharacterClothingData
                 {
                     ComponentIndex = i,
@@ -3158,10 +3159,12 @@ namespace vMenuClient.menus
                 {
                     drawable = GetPedPropIndex(handle, i);
                     collectionName = "base";
+                    character.PropVariations.props[i] = new KeyValuePair<int, int>(drawable, texture);
                 }
                 else
                 {
                     drawable = GetPedCollectionLocalIndexFromProp(handle, i, GetPedPropIndex(handle, i));
+                    character.PropVariations.props[i] = new KeyValuePair<int, int>(GetPedPropGlobalIndexFromCollection(handle, i, collectionName, drawable), texture);
                 }
 
 
@@ -3178,7 +3181,6 @@ namespace vMenuClient.menus
                     continue;
                 }
 
-                character.PropVariations.props[i] = new KeyValuePair<int, int>(drawable, texture);
                 character.PropVariations.propsWithCollection[i] = new CharacterPropData
                 {
                     PropIndex = i,

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -1446,129 +1446,71 @@ namespace vMenuClient.menus
             #endregion
 
             #region clothes
-            clothesMenu.OnListIndexChange += (_menu, listItem, oldSelectionIndex, newSelectionIndex, realIndex) => ChangeClothingListItem(realIndex, newSelectionIndex, listItem);
-
-            clothesMenu.OnListItemSelect += async (sender, listItem, listIndex, realIndex) =>
+            clothesMenu.OnListIndexChange += (_menu, listItem, oldSelectionIndex, newSelectionIndex, realIndex) =>
             {
                 int componentIndex = realIndex + 1;
+                if (realIndex > 0)
+                {
+                    componentIndex += 1;
+                }
 
-// --- CTRL Manual Drawable Selection ---
-int controlIndex = 0;
-bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
+                int newTextureIndex = 0;
 
-if (isCtrlPressed)
-{
-    string userInput = await GetUserInput("Enter Drawable ID", 5);
+                SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, newSelectionIndex, newTextureIndex, 0);              
 
-    if (string.IsNullOrEmpty(userInput) || 
-        !int.TryParse(userInput, out int drawableId) || 
-        drawableId < 0 || 
-        drawableId >= listItem.ItemsCount)
-    {
-        Notify.Error("Invalid input");
-        return;
-    }
+                currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
+                currentCharacter.DrawableVariations.clothes[componentIndex] = new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
 
-    listItem.ListIndex = drawableId;
-    newSelectionIndex = drawableId;
-}
-else
-{
-    newSelectionIndex = listItem.ListIndex;
-}
+                string collectionName = GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
 
-// --- Apply Component ---
-int newTextureIndex = 0;
+                currentCharacter.DrawableVariations.clothesWithCollection ??= new();              
+                currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] = new CharacterClothingData
+                {
+                    ComponentIndex = componentIndex,
+                    Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
+                    Texture = newTextureIndex,
+                    Collection = collectionName
+                };
 
-SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, newSelectionIndex, newTextureIndex, 0);
-
-// Ensure dictionary exists
-currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
-currentCharacter.DrawableVariations.clothes[componentIndex] =
-    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
-
-// --- Save With Collection ---
-string collectionName =
-    GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
-
-currentCharacter.DrawableVariations.clothesWithCollection ??= new();
-
-currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
-    new CharacterClothingData
-    {
-        ComponentIndex = componentIndex,
-        Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
-        Texture = newTextureIndex,
-        Collection = collectionName
-    };
-
-// --- Update UI Description ---
-int maxTextures =
-    GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
-
-listItem.Description =
-    $"Select a drawable using arrow keys.\n" +
-    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
-    $"Press ~o~ENTER~s~ to cycle textures.\n" +
-    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
+                int maxTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
+                listItem.Description = $"Select a drawable using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
             };
 
-            void ChangeClothingListItem(int itemIndex, int newSelectionIndex, MenuListItem listItem)
+            clothesMenu.OnListItemSelect += (sender, listItem, listIndex, realIndex) =>
             {
-                int componentIndex = itemIndex + 1;
+                var componentIndex = realIndex + 1; // skip face options as that fucks up with inheritance faces
+                if (realIndex > 0) // skip hair features as that is done in the appeareance menu
+                {
+                    componentIndex += 1;
+                }
 
-    if (newSelectionIndex < 0 ||
-        newSelectionIndex >= GetNumberOfPedDrawableVariations(Game.PlayerPed.Handle, componentIndex))
-        return;
+                int textureIndex = GetPedTextureVariation(Game.PlayerPed.Handle, componentIndex);
+                int newTextureIndex = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, listIndex) - 1 < textureIndex + 1 ? 0 : textureIndex + 1;
+                
+                SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, listIndex, newTextureIndex, 0);
 
-    int newTextureIndex = 0;
+                currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
+                currentCharacter.DrawableVariations.clothes[componentIndex] = new KeyValuePair<int, int>(listIndex, newTextureIndex);
 
-    // Apply to ped (client-sided preview)
-    SetPedComponentVariation(
-        Game.PlayerPed.Handle,
-        componentIndex,
-        newSelectionIndex,
-        newTextureIndex,
-        0
-    );
+                string collectionName = GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex);
+                if (string.IsNullOrEmpty(collectionName)) collectionName = "base";
 
-    // Ensure dictionary exists
-    currentCharacter.DrawableVariations.clothes ??=
-        new Dictionary<int, KeyValuePair<int, int>>();
+                currentCharacter.DrawableVariations.clothesWithCollection ??= new Dictionary<int, CharacterClothingData>();
+                currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] = new CharacterClothingData
+                {
+                    ComponentIndex = componentIndex,
+                    Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, listIndex),
+                    Texture = newTextureIndex,
+                    Collection = collectionName
+                };
 
-    currentCharacter.DrawableVariations.clothes[componentIndex] =
-        new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
-
-    // ---- COLLECTION SUPPORT ----
-    string collectionName =
-        GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
-
-    currentCharacter.DrawableVariations.clothesWithCollection ??= new();
-
-    currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
-        new CharacterClothingData
-        {
-            ComponentIndex = componentIndex,
-            Drawable =
-                GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
-            Texture = newTextureIndex,
-            Collection = collectionName
-        };
-
-    int maxTextures =
-        GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
-
-    listItem.Description =
-        $"Press ~o~CTRL~s~ to enter ID.\n" +
-        $"Press ~o~ENTER~s~ to cycle textures.\n" +
-        $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
-            }
+                int maxTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, listIndex);
+                listItem.Description = $"Select a drawable using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
+            };
             #endregion
 
             #region props
-            propsMenu.OnListIndexChange += (_menu, listItem, oldSelectionIndex, newSelectionIndex, realIndex) => ChangePropListItem(realIndex, newSelectionIndex, listItem);
-
-            propsMenu.OnListItemSelect += async (sender, listItem, listIndex, realIndex) =>
+            propsMenu.OnListIndexChange += (_menu, listItem, oldSelectionIndex, newSelectionIndex, realIndex) =>
             {
                 int propIndex = realIndex;
                 if (realIndex == 3)
@@ -1579,174 +1521,120 @@ listItem.Description =
                 {
                     propIndex = 7;
                 }
-                // --- CTRL Manual Drawable Selection ---
-int controlIndex = 0;
-bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
+                int textureIndex = 0;
 
-if (isCtrlPressed)
-{
-    string userInput = await GetUserInput("Enter Prop ID (-1 to clear)", 5);
+                int maxDrawables = GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex);
+                bool isNoProp = newSelectionIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex);
 
-    if (string.IsNullOrEmpty(userInput) ||
-        !int.TryParse(userInput, out int drawableId) ||
-        drawableId < -1 ||
-        drawableId >= listItem.ItemsCount)
-    {
-        Notify.Error("Invalid input");
-        return;
-    }
+                currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
+                currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
 
-    listItem.ListIndex = drawableId;
+                if (isNoProp)
+                {
+                    SetPedPropIndex(Game.PlayerPed.Handle, propIndex, -1, -1, false);
+                    ClearPedProp(Game.PlayerPed.Handle, propIndex);
+                    currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
+                    currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(-1, -1);
+                    currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
+                    currentCharacter.PropVariations.propsWithCollection[propIndex] = new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable = -1,
+                        Texture = -1,
+                        Collection = "base"
+                    };
 
-    if (drawableId == -1)
-    {
-        ClearPedProp(Game.PlayerPed.Handle, propIndex);
-        currentCharacter.PropVariations.props[propIndex] =
-            new KeyValuePair<int, int>(-1, 0);
-        return;
-    }
-}
+                    listItem.Description = "Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
+                }
+                else
+                {
+                    SetPedPropIndex(Game.PlayerPed.Handle, propIndex, newSelectionIndex, textureIndex, true);
+                    currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
+                    currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(newSelectionIndex, textureIndex);
 
-// --- Normal Selection ---
-int listIndex = listItem.ListIndex;
+                    string collectionName = GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, newSelectionIndex);
+                    if (string.IsNullOrEmpty(collectionName)) collectionName = "base";
 
-if (listIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
-    return;
+                    currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
+                    currentCharacter.PropVariations.propsWithCollection[propIndex] = new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable = GetPedCollectionLocalIndexFromProp(Game.PlayerPed.Handle, propIndex, newSelectionIndex),
+                        Texture = textureIndex,
+                        Collection = collectionName
+                    };
 
-int textureIndex =
-    GetPedPropTextureIndex(Game.PlayerPed.Handle, propIndex);
-
-int maxTextures =
-    GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex);
-
-int newTextureIndex =
-    (textureIndex + 1 >= maxTextures) ? 0 : textureIndex + 1;
-
-// Apply Prop
-SetPedPropIndex(Game.PlayerPed.Handle, propIndex, listIndex, newTextureIndex, true);
-
-// Ensure dictionary exists
-currentCharacter.PropVariations.props ??=
-    new Dictionary<int, KeyValuePair<int, int>>();
-
-currentCharacter.PropVariations.props[propIndex] =
-    new KeyValuePair<int, int>(listIndex, newTextureIndex);
-
-// --- Save With Collection ---
-string collectionName =
-    GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, listIndex);
-
-if (string.IsNullOrEmpty(collectionName))
-    collectionName = "base";
-
-currentCharacter.PropVariations.propsWithCollection ??=
-    new Dictionary<int, CharacterPropData>();
-
-currentCharacter.PropVariations.propsWithCollection[propIndex] =
-    new CharacterPropData
-    {
-        PropIndex = propIndex,
-        Drawable =
-            GetPedCollectionLocalIndexFromProp(
-                Game.PlayerPed.Handle,
-                propIndex,
-                listIndex),
-        Texture = newTextureIndex,
-        Collection = collectionName
-    };
-
-// --- Update UI Description ---
-listItem.Description =
-    $"Select a prop using arrow keys.\n" +
-    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
-    $"Press ~o~ENTER~s~ to cycle textures.\n" +
-    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
+                    if (GetPedPropIndex(Game.PlayerPed.Handle, propIndex) == -1)
+                    {
+                        listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
+                    }
+                    else
+                    {
+                        int maxPropTextures = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, newSelectionIndex);
+                        listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{textureIndex + 1} (of {maxPropTextures}).";
+                    }
+                }
             };
 
-            void ChangePropListItem(int itemIndex, int newSelectionIndex, MenuListItem listItem)
+            propsMenu.OnListItemSelect += (sender, listItem, listIndex, realIndex) =>
             {
-                int propIndex = itemIndex;
-                if (itemIndex == 3)
+                var propIndex = realIndex;
+                if (realIndex == 3)
                 {
                     propIndex = 6;
                 }
-                if (itemIndex == 4)
+                if (realIndex == 4)
                 {
                     propIndex = 7;
                 }
 
-                int propIndex = itemIndex;
+                int textureIndex = GetPedPropTextureIndex(Game.PlayerPed.Handle, propIndex);
+                int newTextureIndex = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex) - 1 < textureIndex + 1 ? 0 : textureIndex + 1;
+                if (listIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
+                {
+                    SetPedPropIndex(Game.PlayerPed.Handle, propIndex, -1, -1, false);
+                    ClearPedProp(Game.PlayerPed.Handle, propIndex);
+                    currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
+                    currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(-1, -1);
+                    currentCharacter.PropVariations.propsWithCollection ??= new Dictionary<int, CharacterPropData>();
+                    currentCharacter.PropVariations.propsWithCollection[propIndex] = new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable = -1,
+                        Texture = -1,
+                        Collection = "base"
+                    };
+                    listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
+                }
+                else
+                {
+                    SetPedPropIndex(Game.PlayerPed.Handle, propIndex, listIndex, newTextureIndex, true);
+                    currentCharacter.PropVariations.props ??= new Dictionary<int, KeyValuePair<int, int>>();
+                    currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(listIndex, newTextureIndex);
 
-    if (newSelectionIndex == -1)
-    {
-        ClearPedProp(Game.PlayerPed.Handle, propIndex);
+                    string collectionName = GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, listIndex);
+                    if (string.IsNullOrEmpty(collectionName)) collectionName = "base";
 
-        currentCharacter.PropVariations.props[propIndex] =
-            new KeyValuePair<int, int>(-1, 0);
-
-        return;
-    }
-
-    if (newSelectionIndex < 0 ||
-        newSelectionIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
-        return;
-
-    int newTextureIndex = 0;
-
-    // Apply prop
-    SetPedPropIndex(
-        Game.PlayerPed.Handle,
-        propIndex,
-        newSelectionIndex,
-        newTextureIndex,
-        true
-    );
-
-    // Ensure dictionary exists
-    currentCharacter.PropVariations.props ??=
-        new Dictionary<int, KeyValuePair<int, int>>();
-
-    currentCharacter.PropVariations.props[propIndex] =
-        new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
-
-    // ---- COLLECTION SUPPORT ----
-    string collectionName =
-        GetPedCollectionNameFromProp(
-            Game.PlayerPed.Handle,
-            propIndex,
-            newSelectionIndex
-        );
-
-    if (string.IsNullOrEmpty(collectionName))
-        collectionName = "base";
-
-    currentCharacter.PropVariations.propsWithCollection ??=
-        new Dictionary<int, CharacterPropData>();
-
-    currentCharacter.PropVariations.propsWithCollection[propIndex] =
-        new CharacterPropData
-        {
-            PropIndex = propIndex,
-            Drawable =
-                GetPedCollectionLocalIndexFromProp(
-                    Game.PlayerPed.Handle,
-                    propIndex,
-                    newSelectionIndex),
-            Texture = newTextureIndex,
-            Collection = collectionName
-        };
-
-    int maxTextures =
-        GetNumberOfPedPropTextureVariations(
-            Game.PlayerPed.Handle,
-            propIndex,
-            newSelectionIndex);
-
-    listItem.Description =
-        $"Press ~o~CTRL~s~ to enter ID (-1 clears).\n" +
-        $"Press ~o~ENTER~s~ to cycle textures.\n" +
-        $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
-            }
+                    currentCharacter.PropVariations.props[propIndex] = new KeyValuePair<int, int>(listIndex, newTextureIndex);
+                    currentCharacter.PropVariations.propsWithCollection[propIndex] = new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable = GetPedCollectionLocalIndexFromProp(Game.PlayerPed.Handle, propIndex, listIndex),
+                        Texture = newTextureIndex,
+                        Collection = collectionName
+                    };
+                    if (GetPedPropIndex(Game.PlayerPed.Handle, propIndex) == -1)
+                    {
+                        listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures.";
+                    }
+                    else
+                    {
+                        var maxPropTextures = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex);
+                        listItem.Description = $"Select a prop using the arrow keys and press ~o~enter~s~ to cycle through all available textures. Currently selected texture: #{newTextureIndex + 1} (of {maxPropTextures}).";
+                    }
+                }
+                //propsMenu.UpdateScaleform();
+            };
             #endregion
 
             #region face shape data
@@ -1942,30 +1830,9 @@ listItem.Description =
                 }
             };
 
-            tattoosMenu.OnListItemSelect += async (sender, item, tattooIndex, menuIndex) =>
+            tattoosMenu.OnListItemSelect += (sender, item, tattooIndex, menuIndex) =>
             {
                 CreateListsIfNull();
-
-                int controlIndex = 0;
-                bool isBadgesItem = menuIndex == 6;
-                bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
-
-                if (isCtrlPressed)
-                {
-                    string userInput = await GetUserInput($"Enter {(isBadgesItem ? "Badge" : "Tattoo")} ID", 5);
-
-                    if (string.IsNullOrEmpty(userInput) || !int.TryParse(userInput, out int drawableId) || drawableId < 1 || drawableId > item.ItemsCount)
-                    {
-                        Notify.Error("Invalid input");
-                        return;
-                    }
-
-                    drawableId--;
-
-                    item.ListIndex = drawableId;
-
-                    tattooIndex = drawableId;
-                }
 
                 if (menuIndex == 0) // head
                 {
@@ -2057,7 +1924,7 @@ listItem.Description =
                         currentCharacter.PedTatttoos.RightLegTattoos.Add(tat);
                     }
                 }
-                else if (isBadgesItem)
+                else if (menuIndex == 6) // badges
                 {
                     var Tattoo = currentCharacter.IsMale ? MaleTattoosCollection.BADGES.ElementAt(tattooIndex) : FemaleTattoosCollection.BADGES.ElementAt(tattooIndex);
                     var tat = new KeyValuePair<string, string>(Tattoo.collectionName, Tattoo.name);

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -1452,108 +1452,116 @@ namespace vMenuClient.menus
             {
                 int componentIndex = realIndex + 1;
 
-                int controlIndex = 0;
-                bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
-                
-                if (isCtrlPressed)
-                {
-                    string userInput = await GetUserInput("Enter Drawable ID", 5);
-                
-                    if (string.IsNullOrEmpty(userInput) || 
-                        !int.TryParse(userInput, out int drawableId) || 
-                        drawableId < 0 || 
-                        drawableId >= listItem.ItemsCount)
-                    {
-                        Notify.Error("Invalid input");
-                        return;
-                    }
-                
-                    listItem.ListIndex = drawableId;
-                    newSelectionIndex = drawableId;
-                }
-                else
-                {
-                    newSelectionIndex = listItem.ListIndex;
-                }
-                
-                int newTextureIndex = 0;
-                
-                SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, newSelectionIndex, newTextureIndex, 0);
+// --- CTRL Manual Drawable Selection ---
+int controlIndex = 0;
+bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
 
-                currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
-                currentCharacter.DrawableVariations.clothes[componentIndex] =
-                    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
+if (isCtrlPressed)
+{
+    string userInput = await GetUserInput("Enter Drawable ID", 5);
 
-                string collectionName =
-                    GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
-                
-                currentCharacter.DrawableVariations.clothesWithCollection ??= new();
-                
-                currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
-                    new CharacterClothingData
-                    {
-                        ComponentIndex = componentIndex,
-                        Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
-                        Texture = newTextureIndex,
-                        Collection = collectionName
-                    };
+    if (string.IsNullOrEmpty(userInput) || 
+        !int.TryParse(userInput, out int drawableId) || 
+        drawableId < 0 || 
+        drawableId >= listItem.ItemsCount)
+    {
+        Notify.Error("Invalid input");
+        return;
+    }
 
-                int maxTextures =
-                    GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
-                
-                listItem.Description =
-                    $"Select a drawable using arrow keys.\n" +
-                    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
-                    $"Press ~o~ENTER~s~ to cycle textures.\n" +
-                    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
+    listItem.ListIndex = drawableId;
+    newSelectionIndex = drawableId;
+}
+else
+{
+    newSelectionIndex = listItem.ListIndex;
+}
+
+// --- Apply Component ---
+int newTextureIndex = 0;
+
+SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, newSelectionIndex, newTextureIndex, 0);
+
+// Ensure dictionary exists
+currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
+currentCharacter.DrawableVariations.clothes[componentIndex] =
+    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
+
+// --- Save With Collection ---
+string collectionName =
+    GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
+
+currentCharacter.DrawableVariations.clothesWithCollection ??= new();
+
+currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
+    new CharacterClothingData
+    {
+        ComponentIndex = componentIndex,
+        Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
+        Texture = newTextureIndex,
+        Collection = collectionName
+    };
+
+// --- Update UI Description ---
+int maxTextures =
+    GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
+
+listItem.Description =
+    $"Select a drawable using arrow keys.\n" +
+    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
+    $"Press ~o~ENTER~s~ to cycle textures.\n" +
+    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
             };
 
             void ChangeClothingListItem(int itemIndex, int newSelectionIndex, MenuListItem listItem)
             {
                 int componentIndex = itemIndex + 1;
 
-                if (newSelectionIndex < 0 ||
-                    newSelectionIndex >= GetNumberOfPedDrawableVariations(Game.PlayerPed.Handle, componentIndex))
-                    return;
-            
-                int newTextureIndex = 0;
+    if (newSelectionIndex < 0 ||
+        newSelectionIndex >= GetNumberOfPedDrawableVariations(Game.PlayerPed.Handle, componentIndex))
+        return;
 
-                SetPedComponentVariation(
-                    Game.PlayerPed.Handle,
-                    componentIndex,
-                    newSelectionIndex,
-                    newTextureIndex,
-                    0
-                );
+    int newTextureIndex = 0;
 
-                currentCharacter.DrawableVariations.clothes ??=
-                    new Dictionary<int, KeyValuePair<int, int>>();
-            
-                currentCharacter.DrawableVariations.clothes[componentIndex] =
-                    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
-            
-                string collectionName =
-                    GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
-            
-                currentCharacter.DrawableVariations.clothesWithCollection ??= new();
-            
-                currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
-                    new CharacterClothingData
-                    {
-                        ComponentIndex = componentIndex,
-                        Drawable =
-                            GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
-                        Texture = newTextureIndex,
-                        Collection = collectionName
-                    };
-            
-                int maxTextures =
-                    GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
-            
-                listItem.Description =
-                    $"Press ~o~CTRL~s~ to enter ID.\n" +
-                    $"Press ~o~ENTER~s~ to cycle textures.\n" +
-                    $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
+    // Apply to ped (client-sided preview)
+    SetPedComponentVariation(
+        Game.PlayerPed.Handle,
+        componentIndex,
+        newSelectionIndex,
+        newTextureIndex,
+        0
+    );
+
+    // Ensure dictionary exists
+    currentCharacter.DrawableVariations.clothes ??=
+        new Dictionary<int, KeyValuePair<int, int>>();
+
+    currentCharacter.DrawableVariations.clothes[componentIndex] =
+        new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
+
+    // ---- COLLECTION SUPPORT ----
+    string collectionName =
+        GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
+
+    currentCharacter.DrawableVariations.clothesWithCollection ??= new();
+
+    currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
+        new CharacterClothingData
+        {
+            ComponentIndex = componentIndex,
+            Drawable =
+                GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
+            Texture = newTextureIndex,
+            Collection = collectionName
+        };
+
+    int maxTextures =
+        GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
+
+    listItem.Description =
+        $"Press ~o~CTRL~s~ to enter ID.\n" +
+        $"Press ~o~ENTER~s~ to cycle textures.\n" +
+        $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
             }
             #endregion
 
@@ -1571,82 +1579,88 @@ namespace vMenuClient.menus
                 {
                     propIndex = 7;
                 }
-                int controlIndex = 0;
-                bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
-                
-                if (isCtrlPressed)
-                {
-                    string userInput = await GetUserInput("Enter Prop ID (-1 to clear)", 5);
-                
-                    if (string.IsNullOrEmpty(userInput) ||
-                        !int.TryParse(userInput, out int drawableId) ||
-                        drawableId < -1 ||
-                        drawableId >= listItem.ItemsCount)
-                    {
-                        Notify.Error("Invalid input");
-                        return;
-                    }
-                
-                    listItem.ListIndex = drawableId;
-                
-                    if (drawableId == -1)
-                    {
-                        ClearPedProp(Game.PlayerPed.Handle, propIndex);
-                        currentCharacter.PropVariations.props[propIndex] =
-                            new KeyValuePair<int, int>(-1, 0);
-                        return;
-                    }
-                }
-                
-                int listIndex = listItem.ListIndex;
-                
-                if (listIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
-                    return;
-                
-                int textureIndex =
-                    GetPedPropTextureIndex(Game.PlayerPed.Handle, propIndex);
-                
-                int maxTextures =
-                    GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex);
-                
-                int newTextureIndex =
-                    (textureIndex + 1 >= maxTextures) ? 0 : textureIndex + 1;
-                
-                SetPedPropIndex(Game.PlayerPed.Handle, propIndex, listIndex, newTextureIndex, true);
-                
-                currentCharacter.PropVariations.props ??=
-                    new Dictionary<int, KeyValuePair<int, int>>();
-                
-                currentCharacter.PropVariations.props[propIndex] =
-                    new KeyValuePair<int, int>(listIndex, newTextureIndex);
-                
-                string collectionName =
-                    GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, listIndex);
-                
-                if (string.IsNullOrEmpty(collectionName))
-                    collectionName = "base";
-                
-                currentCharacter.PropVariations.propsWithCollection ??=
-                    new Dictionary<int, CharacterPropData>();
-                
-                currentCharacter.PropVariations.propsWithCollection[propIndex] =
-                    new CharacterPropData
-                    {
-                        PropIndex = propIndex,
-                        Drawable =
-                            GetPedCollectionLocalIndexFromProp(
-                                Game.PlayerPed.Handle,
-                                propIndex,
-                                listIndex),
-                        Texture = newTextureIndex,
-                        Collection = collectionName
-                    };
-                
-                listItem.Description =
-                    $"Select a prop using arrow keys.\n" +
-                    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
-                    $"Press ~o~ENTER~s~ to cycle textures.\n" +
-                    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
+                // --- CTRL Manual Drawable Selection ---
+int controlIndex = 0;
+bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
+
+if (isCtrlPressed)
+{
+    string userInput = await GetUserInput("Enter Prop ID (-1 to clear)", 5);
+
+    if (string.IsNullOrEmpty(userInput) ||
+        !int.TryParse(userInput, out int drawableId) ||
+        drawableId < -1 ||
+        drawableId >= listItem.ItemsCount)
+    {
+        Notify.Error("Invalid input");
+        return;
+    }
+
+    listItem.ListIndex = drawableId;
+
+    if (drawableId == -1)
+    {
+        ClearPedProp(Game.PlayerPed.Handle, propIndex);
+        currentCharacter.PropVariations.props[propIndex] =
+            new KeyValuePair<int, int>(-1, 0);
+        return;
+    }
+}
+
+// --- Normal Selection ---
+int listIndex = listItem.ListIndex;
+
+if (listIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
+    return;
+
+int textureIndex =
+    GetPedPropTextureIndex(Game.PlayerPed.Handle, propIndex);
+
+int maxTextures =
+    GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex);
+
+int newTextureIndex =
+    (textureIndex + 1 >= maxTextures) ? 0 : textureIndex + 1;
+
+// Apply Prop
+SetPedPropIndex(Game.PlayerPed.Handle, propIndex, listIndex, newTextureIndex, true);
+
+// Ensure dictionary exists
+currentCharacter.PropVariations.props ??=
+    new Dictionary<int, KeyValuePair<int, int>>();
+
+currentCharacter.PropVariations.props[propIndex] =
+    new KeyValuePair<int, int>(listIndex, newTextureIndex);
+
+// --- Save With Collection ---
+string collectionName =
+    GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, listIndex);
+
+if (string.IsNullOrEmpty(collectionName))
+    collectionName = "base";
+
+currentCharacter.PropVariations.propsWithCollection ??=
+    new Dictionary<int, CharacterPropData>();
+
+currentCharacter.PropVariations.propsWithCollection[propIndex] =
+    new CharacterPropData
+    {
+        PropIndex = propIndex,
+        Drawable =
+            GetPedCollectionLocalIndexFromProp(
+                Game.PlayerPed.Handle,
+                propIndex,
+                listIndex),
+        Texture = newTextureIndex,
+        Collection = collectionName
+    };
+
+// --- Update UI Description ---
+listItem.Description =
+    $"Select a prop using arrow keys.\n" +
+    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
+    $"Press ~o~ENTER~s~ to cycle textures.\n" +
+    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
             };
 
             void ChangePropListItem(int itemIndex, int newSelectionIndex, MenuListItem listItem)
@@ -1663,72 +1677,75 @@ namespace vMenuClient.menus
 
                 int propIndex = itemIndex;
 
-                if (newSelectionIndex == -1)
-                {
-                    ClearPedProp(Game.PlayerPed.Handle, propIndex);
-            
-                    currentCharacter.PropVariations.props[propIndex] =
-                        new KeyValuePair<int, int>(-1, 0);
-            
-                    return;
-                }
-            
-                if (newSelectionIndex < 0 ||
-                    newSelectionIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
-                    return;
-            
-                int newTextureIndex = 0;
+    if (newSelectionIndex == -1)
+    {
+        ClearPedProp(Game.PlayerPed.Handle, propIndex);
 
-                SetPedPropIndex(
+        currentCharacter.PropVariations.props[propIndex] =
+            new KeyValuePair<int, int>(-1, 0);
+
+        return;
+    }
+
+    if (newSelectionIndex < 0 ||
+        newSelectionIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
+        return;
+
+    int newTextureIndex = 0;
+
+    // Apply prop
+    SetPedPropIndex(
+        Game.PlayerPed.Handle,
+        propIndex,
+        newSelectionIndex,
+        newTextureIndex,
+        true
+    );
+
+    // Ensure dictionary exists
+    currentCharacter.PropVariations.props ??=
+        new Dictionary<int, KeyValuePair<int, int>>();
+
+    currentCharacter.PropVariations.props[propIndex] =
+        new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
+
+    // ---- COLLECTION SUPPORT ----
+    string collectionName =
+        GetPedCollectionNameFromProp(
+            Game.PlayerPed.Handle,
+            propIndex,
+            newSelectionIndex
+        );
+
+    if (string.IsNullOrEmpty(collectionName))
+        collectionName = "base";
+
+    currentCharacter.PropVariations.propsWithCollection ??=
+        new Dictionary<int, CharacterPropData>();
+
+    currentCharacter.PropVariations.propsWithCollection[propIndex] =
+        new CharacterPropData
+        {
+            PropIndex = propIndex,
+            Drawable =
+                GetPedCollectionLocalIndexFromProp(
                     Game.PlayerPed.Handle,
                     propIndex,
-                    newSelectionIndex,
-                    newTextureIndex,
-                    true
-                );
+                    newSelectionIndex),
+            Texture = newTextureIndex,
+            Collection = collectionName
+        };
 
-                currentCharacter.PropVariations.props ??=
-                    new Dictionary<int, KeyValuePair<int, int>>();
-            
-                currentCharacter.PropVariations.props[propIndex] =
-                    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
+    int maxTextures =
+        GetNumberOfPedPropTextureVariations(
+            Game.PlayerPed.Handle,
+            propIndex,
+            newSelectionIndex);
 
-                string collectionName =
-                    GetPedCollectionNameFromProp(
-                        Game.PlayerPed.Handle,
-                        propIndex,
-                        newSelectionIndex
-                    );
-            
-                if (string.IsNullOrEmpty(collectionName))
-                    collectionName = "base";
-            
-                currentCharacter.PropVariations.propsWithCollection ??=
-                    new Dictionary<int, CharacterPropData>();
-            
-                currentCharacter.PropVariations.propsWithCollection[propIndex] =
-                    new CharacterPropData
-                    {
-                        PropIndex = propIndex,
-                        Drawable =
-                            GetPedCollectionLocalIndexFromProp(
-                                Game.PlayerPed.Handle,
-                                propIndex,
-                                newSelectionIndex),
-                        Texture = newTextureIndex,
-                        Collection = collectionName
-                    };
-            
-                int maxTextures =
-                    GetNumberOfPedPropTextureVariations(
-                        Game.PlayerPed.Handle,
-                        propIndex,
-                        newSelectionIndex);
-            
-                listItem.Description =
-                    $"Press ~o~CTRL~s~ to enter ID (-1 clears).\n" +
-                    $"Press ~o~ENTER~s~ to cycle textures.\n" +
-                    $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
+    listItem.Description =
+        $"Press ~o~CTRL~s~ to enter ID (-1 clears).\n" +
+        $"Press ~o~ENTER~s~ to cycle textures.\n" +
+        $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
             }
             #endregion
 

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -1452,116 +1452,108 @@ namespace vMenuClient.menus
             {
                 int componentIndex = realIndex + 1;
 
-// --- CTRL Manual Drawable Selection ---
-int controlIndex = 0;
-bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
+                int controlIndex = 0;
+                bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
+                
+                if (isCtrlPressed)
+                {
+                    string userInput = await GetUserInput("Enter Drawable ID", 5);
+                
+                    if (string.IsNullOrEmpty(userInput) || 
+                        !int.TryParse(userInput, out int drawableId) || 
+                        drawableId < 0 || 
+                        drawableId >= listItem.ItemsCount)
+                    {
+                        Notify.Error("Invalid input");
+                        return;
+                    }
+                
+                    listItem.ListIndex = drawableId;
+                    newSelectionIndex = drawableId;
+                }
+                else
+                {
+                    newSelectionIndex = listItem.ListIndex;
+                }
+                
+                int newTextureIndex = 0;
+                
+                SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, newSelectionIndex, newTextureIndex, 0);
 
-if (isCtrlPressed)
-{
-    string userInput = await GetUserInput("Enter Drawable ID", 5);
+                currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
+                currentCharacter.DrawableVariations.clothes[componentIndex] =
+                    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
 
-    if (string.IsNullOrEmpty(userInput) || 
-        !int.TryParse(userInput, out int drawableId) || 
-        drawableId < 0 || 
-        drawableId >= listItem.ItemsCount)
-    {
-        Notify.Error("Invalid input");
-        return;
-    }
+                string collectionName =
+                    GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
+                
+                currentCharacter.DrawableVariations.clothesWithCollection ??= new();
+                
+                currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
+                    new CharacterClothingData
+                    {
+                        ComponentIndex = componentIndex,
+                        Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
+                        Texture = newTextureIndex,
+                        Collection = collectionName
+                    };
 
-    listItem.ListIndex = drawableId;
-    newSelectionIndex = drawableId;
-}
-else
-{
-    newSelectionIndex = listItem.ListIndex;
-}
-
-// --- Apply Component ---
-int newTextureIndex = 0;
-
-SetPedComponentVariation(Game.PlayerPed.Handle, componentIndex, newSelectionIndex, newTextureIndex, 0);
-
-// Ensure dictionary exists
-currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
-currentCharacter.DrawableVariations.clothes[componentIndex] =
-    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
-
-// --- Save With Collection ---
-string collectionName =
-    GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
-
-currentCharacter.DrawableVariations.clothesWithCollection ??= new();
-
-currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
-    new CharacterClothingData
-    {
-        ComponentIndex = componentIndex,
-        Drawable = GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
-        Texture = newTextureIndex,
-        Collection = collectionName
-    };
-
-// --- Update UI Description ---
-int maxTextures =
-    GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
-
-listItem.Description =
-    $"Select a drawable using arrow keys.\n" +
-    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
-    $"Press ~o~ENTER~s~ to cycle textures.\n" +
-    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
+                int maxTextures =
+                    GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
+                
+                listItem.Description =
+                    $"Select a drawable using arrow keys.\n" +
+                    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
+                    $"Press ~o~ENTER~s~ to cycle textures.\n" +
+                    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
             };
 
             void ChangeClothingListItem(int itemIndex, int newSelectionIndex, MenuListItem listItem)
             {
                 int componentIndex = itemIndex + 1;
 
-    if (newSelectionIndex < 0 ||
-        newSelectionIndex >= GetNumberOfPedDrawableVariations(Game.PlayerPed.Handle, componentIndex))
-        return;
+                if (newSelectionIndex < 0 ||
+                    newSelectionIndex >= GetNumberOfPedDrawableVariations(Game.PlayerPed.Handle, componentIndex))
+                    return;
+            
+                int newTextureIndex = 0;
 
-    int newTextureIndex = 0;
+                SetPedComponentVariation(
+                    Game.PlayerPed.Handle,
+                    componentIndex,
+                    newSelectionIndex,
+                    newTextureIndex,
+                    0
+                );
 
-    // Apply to ped (client-sided preview)
-    SetPedComponentVariation(
-        Game.PlayerPed.Handle,
-        componentIndex,
-        newSelectionIndex,
-        newTextureIndex,
-        0
-    );
-
-    // Ensure dictionary exists
-    currentCharacter.DrawableVariations.clothes ??=
-        new Dictionary<int, KeyValuePair<int, int>>();
-
-    currentCharacter.DrawableVariations.clothes[componentIndex] =
-        new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
-
-    // ---- COLLECTION SUPPORT ----
-    string collectionName =
-        GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
-
-    currentCharacter.DrawableVariations.clothesWithCollection ??= new();
-
-    currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
-        new CharacterClothingData
-        {
-            ComponentIndex = componentIndex,
-            Drawable =
-                GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
-            Texture = newTextureIndex,
-            Collection = collectionName
-        };
-
-    int maxTextures =
-        GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
-
-    listItem.Description =
-        $"Press ~o~CTRL~s~ to enter ID.\n" +
-        $"Press ~o~ENTER~s~ to cycle textures.\n" +
-        $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
+                currentCharacter.DrawableVariations.clothes ??=
+                    new Dictionary<int, KeyValuePair<int, int>>();
+            
+                currentCharacter.DrawableVariations.clothes[componentIndex] =
+                    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
+            
+                string collectionName =
+                    GetPedDrawableVariationCollectionName(Game.PlayerPed.Handle, componentIndex) ?? "base";
+            
+                currentCharacter.DrawableVariations.clothesWithCollection ??= new();
+            
+                currentCharacter.DrawableVariations.clothesWithCollection[componentIndex] =
+                    new CharacterClothingData
+                    {
+                        ComponentIndex = componentIndex,
+                        Drawable =
+                            GetPedDrawableVariationCollectionLocalIndex(componentIndex, newSelectionIndex),
+                        Texture = newTextureIndex,
+                        Collection = collectionName
+                    };
+            
+                int maxTextures =
+                    GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, componentIndex, newSelectionIndex);
+            
+                listItem.Description =
+                    $"Press ~o~CTRL~s~ to enter ID.\n" +
+                    $"Press ~o~ENTER~s~ to cycle textures.\n" +
+                    $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
             }
             #endregion
 
@@ -1579,88 +1571,82 @@ listItem.Description =
                 {
                     propIndex = 7;
                 }
-                // --- CTRL Manual Drawable Selection ---
-int controlIndex = 0;
-bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
-
-if (isCtrlPressed)
-{
-    string userInput = await GetUserInput("Enter Prop ID (-1 to clear)", 5);
-
-    if (string.IsNullOrEmpty(userInput) ||
-        !int.TryParse(userInput, out int drawableId) ||
-        drawableId < -1 ||
-        drawableId >= listItem.ItemsCount)
-    {
-        Notify.Error("Invalid input");
-        return;
-    }
-
-    listItem.ListIndex = drawableId;
-
-    if (drawableId == -1)
-    {
-        ClearPedProp(Game.PlayerPed.Handle, propIndex);
-        currentCharacter.PropVariations.props[propIndex] =
-            new KeyValuePair<int, int>(-1, 0);
-        return;
-    }
-}
-
-// --- Normal Selection ---
-int listIndex = listItem.ListIndex;
-
-if (listIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
-    return;
-
-int textureIndex =
-    GetPedPropTextureIndex(Game.PlayerPed.Handle, propIndex);
-
-int maxTextures =
-    GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex);
-
-int newTextureIndex =
-    (textureIndex + 1 >= maxTextures) ? 0 : textureIndex + 1;
-
-// Apply Prop
-SetPedPropIndex(Game.PlayerPed.Handle, propIndex, listIndex, newTextureIndex, true);
-
-// Ensure dictionary exists
-currentCharacter.PropVariations.props ??=
-    new Dictionary<int, KeyValuePair<int, int>>();
-
-currentCharacter.PropVariations.props[propIndex] =
-    new KeyValuePair<int, int>(listIndex, newTextureIndex);
-
-// --- Save With Collection ---
-string collectionName =
-    GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, listIndex);
-
-if (string.IsNullOrEmpty(collectionName))
-    collectionName = "base";
-
-currentCharacter.PropVariations.propsWithCollection ??=
-    new Dictionary<int, CharacterPropData>();
-
-currentCharacter.PropVariations.propsWithCollection[propIndex] =
-    new CharacterPropData
-    {
-        PropIndex = propIndex,
-        Drawable =
-            GetPedCollectionLocalIndexFromProp(
-                Game.PlayerPed.Handle,
-                propIndex,
-                listIndex),
-        Texture = newTextureIndex,
-        Collection = collectionName
-    };
-
-// --- Update UI Description ---
-listItem.Description =
-    $"Select a prop using arrow keys.\n" +
-    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
-    $"Press ~o~ENTER~s~ to cycle textures.\n" +
-    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
+                int controlIndex = 0;
+                bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
+                
+                if (isCtrlPressed)
+                {
+                    string userInput = await GetUserInput("Enter Prop ID (-1 to clear)", 5);
+                
+                    if (string.IsNullOrEmpty(userInput) ||
+                        !int.TryParse(userInput, out int drawableId) ||
+                        drawableId < -1 ||
+                        drawableId >= listItem.ItemsCount)
+                    {
+                        Notify.Error("Invalid input");
+                        return;
+                    }
+                
+                    listItem.ListIndex = drawableId;
+                
+                    if (drawableId == -1)
+                    {
+                        ClearPedProp(Game.PlayerPed.Handle, propIndex);
+                        currentCharacter.PropVariations.props[propIndex] =
+                            new KeyValuePair<int, int>(-1, 0);
+                        return;
+                    }
+                }
+                
+                int listIndex = listItem.ListIndex;
+                
+                if (listIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
+                    return;
+                
+                int textureIndex =
+                    GetPedPropTextureIndex(Game.PlayerPed.Handle, propIndex);
+                
+                int maxTextures =
+                    GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, propIndex, listIndex);
+                
+                int newTextureIndex =
+                    (textureIndex + 1 >= maxTextures) ? 0 : textureIndex + 1;
+                
+                SetPedPropIndex(Game.PlayerPed.Handle, propIndex, listIndex, newTextureIndex, true);
+                
+                currentCharacter.PropVariations.props ??=
+                    new Dictionary<int, KeyValuePair<int, int>>();
+                
+                currentCharacter.PropVariations.props[propIndex] =
+                    new KeyValuePair<int, int>(listIndex, newTextureIndex);
+                
+                string collectionName =
+                    GetPedCollectionNameFromProp(Game.PlayerPed.Handle, propIndex, listIndex);
+                
+                if (string.IsNullOrEmpty(collectionName))
+                    collectionName = "base";
+                
+                currentCharacter.PropVariations.propsWithCollection ??=
+                    new Dictionary<int, CharacterPropData>();
+                
+                currentCharacter.PropVariations.propsWithCollection[propIndex] =
+                    new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable =
+                            GetPedCollectionLocalIndexFromProp(
+                                Game.PlayerPed.Handle,
+                                propIndex,
+                                listIndex),
+                        Texture = newTextureIndex,
+                        Collection = collectionName
+                    };
+                
+                listItem.Description =
+                    $"Select a prop using arrow keys.\n" +
+                    $"Press ~o~CTRL~s~ to manually enter ID.\n" +
+                    $"Press ~o~ENTER~s~ to cycle textures.\n" +
+                    $"Currently selected texture: #{newTextureIndex + 1} (of {maxTextures}).";
             };
 
             void ChangePropListItem(int itemIndex, int newSelectionIndex, MenuListItem listItem)
@@ -1677,75 +1663,72 @@ listItem.Description =
 
                 int propIndex = itemIndex;
 
-    if (newSelectionIndex == -1)
-    {
-        ClearPedProp(Game.PlayerPed.Handle, propIndex);
+                if (newSelectionIndex == -1)
+                {
+                    ClearPedProp(Game.PlayerPed.Handle, propIndex);
+            
+                    currentCharacter.PropVariations.props[propIndex] =
+                        new KeyValuePair<int, int>(-1, 0);
+            
+                    return;
+                }
+            
+                if (newSelectionIndex < 0 ||
+                    newSelectionIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
+                    return;
+            
+                int newTextureIndex = 0;
 
-        currentCharacter.PropVariations.props[propIndex] =
-            new KeyValuePair<int, int>(-1, 0);
-
-        return;
-    }
-
-    if (newSelectionIndex < 0 ||
-        newSelectionIndex >= GetNumberOfPedPropDrawableVariations(Game.PlayerPed.Handle, propIndex))
-        return;
-
-    int newTextureIndex = 0;
-
-    // Apply prop
-    SetPedPropIndex(
-        Game.PlayerPed.Handle,
-        propIndex,
-        newSelectionIndex,
-        newTextureIndex,
-        true
-    );
-
-    // Ensure dictionary exists
-    currentCharacter.PropVariations.props ??=
-        new Dictionary<int, KeyValuePair<int, int>>();
-
-    currentCharacter.PropVariations.props[propIndex] =
-        new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
-
-    // ---- COLLECTION SUPPORT ----
-    string collectionName =
-        GetPedCollectionNameFromProp(
-            Game.PlayerPed.Handle,
-            propIndex,
-            newSelectionIndex
-        );
-
-    if (string.IsNullOrEmpty(collectionName))
-        collectionName = "base";
-
-    currentCharacter.PropVariations.propsWithCollection ??=
-        new Dictionary<int, CharacterPropData>();
-
-    currentCharacter.PropVariations.propsWithCollection[propIndex] =
-        new CharacterPropData
-        {
-            PropIndex = propIndex,
-            Drawable =
-                GetPedCollectionLocalIndexFromProp(
+                SetPedPropIndex(
                     Game.PlayerPed.Handle,
                     propIndex,
-                    newSelectionIndex),
-            Texture = newTextureIndex,
-            Collection = collectionName
-        };
+                    newSelectionIndex,
+                    newTextureIndex,
+                    true
+                );
 
-    int maxTextures =
-        GetNumberOfPedPropTextureVariations(
-            Game.PlayerPed.Handle,
-            propIndex,
-            newSelectionIndex);
+                currentCharacter.PropVariations.props ??=
+                    new Dictionary<int, KeyValuePair<int, int>>();
+            
+                currentCharacter.PropVariations.props[propIndex] =
+                    new KeyValuePair<int, int>(newSelectionIndex, newTextureIndex);
 
-    listItem.Description =
-        $"Press ~o~CTRL~s~ to enter ID (-1 clears).\n" +
-        $"Press ~o~ENTER~s~ to cycle textures.\n" +
-        $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
+                string collectionName =
+                    GetPedCollectionNameFromProp(
+                        Game.PlayerPed.Handle,
+                        propIndex,
+                        newSelectionIndex
+                    );
+            
+                if (string.IsNullOrEmpty(collectionName))
+                    collectionName = "base";
+            
+                currentCharacter.PropVariations.propsWithCollection ??=
+                    new Dictionary<int, CharacterPropData>();
+            
+                currentCharacter.PropVariations.propsWithCollection[propIndex] =
+                    new CharacterPropData
+                    {
+                        PropIndex = propIndex,
+                        Drawable =
+                            GetPedCollectionLocalIndexFromProp(
+                                Game.PlayerPed.Handle,
+                                propIndex,
+                                newSelectionIndex),
+                        Texture = newTextureIndex,
+                        Collection = collectionName
+                    };
+            
+                int maxTextures =
+                    GetNumberOfPedPropTextureVariations(
+                        Game.PlayerPed.Handle,
+                        propIndex,
+                        newSelectionIndex);
+            
+                listItem.Description =
+                    $"Press ~o~CTRL~s~ to enter ID (-1 clears).\n" +
+                    $"Press ~o~ENTER~s~ to cycle textures.\n" +
+                    $"Current texture: #{newTextureIndex + 1} (of {maxTextures}).";
             }
             #endregion
 

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -617,7 +617,6 @@ namespace vMenuClient.menus
                     {
                         ShowVisorText(Game.PlayerPed.Handle);
                     }
-
                 }
             }
             #endregion

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -540,61 +540,7 @@ namespace vMenuClient.menus
 
             #region ped drawable list changes
             // Manage list changes.
-            pedCustomizationMenu.OnListIndexChange += (sender, item, oldListIndex, newListIndex, itemIndex) => ChangeListItem(item, newListIndex);
-
-            // Manage list selections.
-            pedCustomizationMenu.OnListItemSelect += async (sender, item, listIndex, itemIndex) =>
-            {
-                int controlIndex = 0;
-                bool isDrawable = drawablesMenuListItems.ContainsKey(item);
-                bool isCtrlPressed = Game.IsControlPressed(controlIndex, Control.Duck);
-
-                if (isCtrlPressed)
-                {
-                    string userInput = await GetUserInput($"Enter {(isDrawable ? "Drawable" : "Prop")} ID", 5);
-
-                    if (string.IsNullOrEmpty(userInput) || !int.TryParse(userInput, out int drawableId) || drawableId < 1 || drawableId > item.ItemsCount)
-                    {
-                        Notify.Error("Invalid input");
-                        return;
-                    }
-
-                    drawableId--;
-
-                    item.ListIndex = drawableId;
-
-                    ChangeListItem(item, drawableId);
-                    return;
-                }
-
-                if (isDrawable)
-                {
-                    var currentDrawableID = drawablesMenuListItems[item];
-                    var currentTextureIndex = GetPedTextureVariation(Game.PlayerPed.Handle, currentDrawableID);
-                    var maxDrawableTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, currentDrawableID, listIndex) - 1;
-
-                    if (currentTextureIndex == -1)
-                    {
-                        currentTextureIndex = 0;
-                    }
-
-                    var newTexture = currentTextureIndex < maxDrawableTextures ? currentTextureIndex + 1 : 0;
-
-                    SetPedComponentVariation(Game.PlayerPed.Handle, currentDrawableID, listIndex, newTexture, 0);
-                }
-                else // prop
-                {
-                    var currentPropIndex = propsMenuListItems[item];
-                    var currentPropVariationIndex = GetPedPropIndex(Game.PlayerPed.Handle, currentPropIndex);
-                    var currentPropTextureVariation = GetPedPropTextureIndex(Game.PlayerPed.Handle, currentPropIndex);
-                    var maxPropTextureVariations = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, currentPropIndex, currentPropVariationIndex) - 1;
-
-                    var newPropTextureVariationIndex = currentPropTextureVariation < maxPropTextureVariations ? currentPropTextureVariation + 1 : 0;
-                    SetPedPropIndex(Game.PlayerPed.Handle, currentPropIndex, currentPropVariationIndex, newPropTextureVariationIndex, true);
-                }
-            };
-
-            void ChangeListItem(MenuListItem item, int newListIndex)
+            pedCustomizationMenu.OnListIndexChange += (sender, item, oldListIndex, newListIndex, itemIndex) =>
             {
                 if (drawablesMenuListItems.ContainsKey(item))
                 {
@@ -617,8 +563,39 @@ namespace vMenuClient.menus
                     {
                         ShowVisorText(Game.PlayerPed.Handle);
                     }
+
                 }
-            }
+            };
+
+            // Manage list selections.
+            pedCustomizationMenu.OnListItemSelect += (sender, item, listIndex, itemIndex) =>
+            {
+                if (drawablesMenuListItems.ContainsKey(item)) // drawable
+                {
+                    var currentDrawableID = drawablesMenuListItems[item];
+                    var currentTextureIndex = GetPedTextureVariation(Game.PlayerPed.Handle, currentDrawableID);
+                    var maxDrawableTextures = GetNumberOfPedTextureVariations(Game.PlayerPed.Handle, currentDrawableID, listIndex) - 1;
+
+                    if (currentTextureIndex == -1)
+                    {
+                        currentTextureIndex = 0;
+                    }
+
+                    var newTexture = currentTextureIndex < maxDrawableTextures ? currentTextureIndex + 1 : 0;
+
+                    SetPedComponentVariation(Game.PlayerPed.Handle, currentDrawableID, listIndex, newTexture, 0);
+                }
+                else if (propsMenuListItems.ContainsKey(item)) // prop
+                {
+                    var currentPropIndex = propsMenuListItems[item];
+                    var currentPropVariationIndex = GetPedPropIndex(Game.PlayerPed.Handle, currentPropIndex);
+                    var currentPropTextureVariation = GetPedPropTextureIndex(Game.PlayerPed.Handle, currentPropIndex);
+                    var maxPropTextureVariations = GetNumberOfPedPropTextureVariations(Game.PlayerPed.Handle, currentPropIndex, currentPropVariationIndex) - 1;
+
+                    var newPropTextureVariationIndex = currentPropTextureVariation < maxPropTextureVariations ? currentPropTextureVariation + 1 : 0;
+                    SetPedPropIndex(Game.PlayerPed.Handle, currentPropIndex, currentPropVariationIndex, newPropTextureVariationIndex, true);
+                }
+            };
             #endregion
 
             pedCollectionsCustomizationMenu.OnListIndexChange += (_, item, oldListIndex, newListIndex, ___) =>

--- a/vMenu/vMenuClient.csproj
+++ b/vMenu/vMenuClient.csproj
@@ -16,7 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CitizenFX.Core.Client" Version="1.0.10230" />
+    <PackageReference Include="CitizenFX.Core.Client" Version="1.0.10230">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="MenuAPI.FiveM" Version="3.2.2" />
 
     <Reference Include="Microsoft.CSharp" />

--- a/vMenu/vMenuClient.csproj
+++ b/vMenu/vMenuClient.csproj
@@ -16,13 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CitizenFX.Core.Client" Version="1.0.10230" />
     <PackageReference Include="MenuAPI.FiveM" Version="3.2.2" />
 
     <Reference Include="Microsoft.CSharp" />
-    
-    <PackageReference Include="CitizenFX.Core.Client" Version="1.0.10188">
-      <ExcludeAssets>runtime</ExcludeAssets>
-    </PackageReference>
     
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\dependencies\shared\Newtonsoft.Json.dll</HintPath>


### PR DESCRIPTION
Saves MP Ped clothes by collection instead of global ID to allow saved beds to be the same across various game builds. Primarily useful for servers using addon drawables. Includes support for legacy saves to preserve continuity. 

Also updates CitizenFX.Core.Client API to 1.0.10230 to enable the use of the new natives.

Tested using b3095, 3258, and 3407 without issues.