### PR TITLE
Prevent Abuse of Vehicle Extras Menu to Repair Vehicles

### DIFF
--- a/SharedClasses/ConfigManager.cs
+++ b/SharedClasses/ConfigManager.cs
@@ -42,7 +42,6 @@ namespace vMenuShared
             vmenu_prevent_extras_when_damaged,
             vmenu_prevent_extras_engine_damage,
             vmenu_prevent_extras_body_damage,
-            vmenu_prevent_extras_notification_enabled,
 
             // MP Ped preview setting,
             vmenu_mp_ped_preview,

--- a/SharedClasses/ConfigManager.cs
+++ b/SharedClasses/ConfigManager.cs
@@ -38,6 +38,12 @@ namespace vMenuShared
             // Vehicle Chameleon Colours
             vmenu_using_chameleon_colours,
 
+            // Prevent Extras Abuse
+            vmenu_prevent_extras_when_damaged,
+            vmenu_prevent_extras_engine_damage,
+            vmenu_prevent_extras_body_damage,
+            vmenu_prevent_extras_notification_enabled,
+
             // MP Ped preview setting,
             vmenu_mp_ped_preview,
 

--- a/SharedClasses/ConfigManager.cs
+++ b/SharedClasses/ConfigManager.cs
@@ -38,13 +38,6 @@ namespace vMenuShared
             // Vehicle Chameleon Colours
             vmenu_using_chameleon_colours,
 
-            // Vehicle Prevent Extras When Damaged
-            vmenu_prevent_extras_when_damaged,
-            vmenu_prevent_extras_engine_damage,
-            vmenu_prevent_extras_body_damage,
-            vmenu_prevent_extras_notification_enabled,
-            vmenu_prevent_extras_notification_text,
-
             // MP Ped preview setting,
             vmenu_mp_ped_preview,
 

--- a/SharedClasses/ConfigManager.cs
+++ b/SharedClasses/ConfigManager.cs
@@ -40,8 +40,8 @@ namespace vMenuShared
 
             // Prevent Extras Abuse
             vmenu_prevent_extras_when_damaged,
-            vmenu_prevent_extras_engine_damage,
-            vmenu_prevent_extras_body_damage,
+            vmenu_allowed_engine_damage_for_extra_change,
+            vmenu_allowed_body_damage_for_extra_change,
 
             // MP Ped preview setting,
             vmenu_mp_ped_preview,

--- a/SharedClasses/ConfigManager.cs
+++ b/SharedClasses/ConfigManager.cs
@@ -38,6 +38,13 @@ namespace vMenuShared
             // Vehicle Chameleon Colours
             vmenu_using_chameleon_colours,
 
+            // Vehicle Prevent Extras When Damaged
+            vmenu_prevent_extras_when_damaged,
+            vmenu_prevent_extras_engine_damage,
+            vmenu_prevent_extras_body_damage,
+            vmenu_prevent_extras_notification_enabled,
+            vmenu_prevent_extras_notification_text,
+
             // MP Ped preview setting,
             vmenu_mp_ped_preview,
 

--- a/vMenu/EventManager.cs
+++ b/vMenu/EventManager.cs
@@ -284,7 +284,6 @@ namespace vMenuClient
         /// <returns></returns>
         private async Task WeatherSync()
         {
-
             await UpdateWeatherParticles();
             SetArtificialLightsState(IsBlackoutEnabled);
             SetArtificialLightsStateAffectsVehicles(!IsVehicleLightsEnabled);

--- a/vMenu/EventManager.cs
+++ b/vMenu/EventManager.cs
@@ -284,10 +284,6 @@ namespace vMenuClient
         /// <returns></returns>
         private async Task WeatherSync()
         {
-            if (MainMenu.WeatherOptionsMenu == null)
-            {
-                return;
-            }
 
             await UpdateWeatherParticles();
             SetArtificialLightsState(IsBlackoutEnabled);

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1709,10 +1709,8 @@ namespace vMenuClient.menus
                         (GetVehicleBodyHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_engine_damage) || 
                         GetVehicleEngineHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_body_damage)))
                         {
-                            if (GetSettingsBool(Setting.vmenu_prevent_extras_notification_enabled))
-                            {
-                                Notify.Alert("Vehicle is too damaged to change extra, repair it first!", true, false);
-                            }
+                            // Send message to player when extra change is denied
+                            Notify.Alert("Vehicle is too damaged to change extra, repair it first!", true, false);
                            
                             // Revert checkbox back to original state
                             ((MenuCheckboxItem)item).Checked = veh.IsExtraOn(extra);

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 
 using CitizenFX.Core;
-using CitizenFX.Core.Native;
-using CitizenFX.Core.UI;
 
 using MenuAPI;
 
@@ -1704,7 +1702,7 @@ namespace vMenuClient.menus
                 if (vehicleExtras.TryGetValue(item, out var extra))
                 {
                     var veh = GetVehicle();
-                    if (veh != null && veh.Exists())
+                    if (Entity.Exists(veh))
                     {
                         // If vmenu_prevent_extras_when_damaged is enabled, check vehicle engine and body health
                         if (GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged) && 
@@ -1713,15 +1711,13 @@ namespace vMenuClient.menus
                         {
                             if (GetSettingsBool(Setting.vmenu_prevent_extras_notification_enabled))
                             {
-                                Screen.ShowNotification(GetSettingsString(Setting.vmenu_prevent_extras_notification_text));
+                                Notify.Alert("Vehicle is too damaged to change extra, repair it first!", true, false);
                             }
                            
                             // Revert checkbox back to original state
                             ((MenuCheckboxItem)item).Checked = veh.IsExtraOn(extra);
                             return;
                         }
-
-                        veh.ToggleExtra(extra, _checked);
                     }
                 }
             };

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1706,8 +1706,8 @@ namespace vMenuClient.menus
                     {
                         // If vmenu_prevent_extras_when_damaged is enabled, check vehicle engine and body health
                         if (GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged) && 
-                        (API.GetVehicleBodyHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_engine_damage) || 
-                        API.GetVehicleEngineHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_body_damage)))
+                        (GetVehicleBodyHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_engine_damage) || 
+                        GetVehicleEngineHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_body_damage)))
                         {
                             if (GetSettingsBool(Setting.vmenu_prevent_extras_notification_enabled))
                             {
@@ -1718,6 +1718,7 @@ namespace vMenuClient.menus
                             ((MenuCheckboxItem)item).Checked = veh.IsExtraOn(extra);
                             return;
                         }
+                        veh.ToggleExtra(extra, _checked);
                     }
                 }
             };

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1694,6 +1694,52 @@ namespace vMenuClient.menus
                     }
                 }
             };
+
+            // Disable all extra options if vehicle is too damaged
+            VehicleComponentsMenu.OnMenuOpen += (menu) =>
+            {
+                Vehicle vehicle;
+                bool checkDamageBeforeChangingExtras = GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged);
+
+                if (!checkDamageBeforeChangingExtras || !Entity.Exists(vehicle = GetVehicle()))
+                {
+                    return;
+                }
+
+                List<MenuItem> menuItems = menu.GetMenuItems();
+                bool isTooDamaged = IsVehicleTooDamagedToChangeExtras(vehicle);
+
+                menu.ClearMenuItems();
+
+                if (isTooDamaged && !menuItems.Exists(i => i.Text.Contains("too damaged")))
+                {
+                    MenuItem spacer = GetSpacerMenuItem("Vehicle too damaged!", "Vehicle is too damaged to change extras, repair it first!");
+
+                    // Place at the start of the menu
+                    menuItems.Insert(0, spacer);
+                }
+
+                foreach (MenuItem item in menuItems)
+                {
+                    // Check for spacer
+                    if (item.Text.Contains("too damaged"))
+                    {
+                        if (!isTooDamaged)
+                        {
+                            continue;
+                        }
+                    }
+                    else if (item.Text != "Go Back")
+                    {
+                        item.Enabled = !isTooDamaged;
+                    }
+
+                    menu.AddMenuItem(item);
+                }
+
+                menu.RefreshIndex();
+            };
+
             // when a checkbox in the components menu changes
             VehicleComponentsMenu.OnCheckboxChange += (sender, item, index, _checked) =>
             {
@@ -1702,22 +1748,31 @@ namespace vMenuClient.menus
                 if (vehicleExtras.TryGetValue(item, out var extra))
                 {
                     var veh = GetVehicle();
-                    if (Entity.Exists(veh))
+
+                    if (!Entity.Exists(veh))
                     {
-                        // If vmenu_prevent_extras_when_damaged is enabled, check vehicle engine and body health
-                        if (GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged) && 
-                        (GetVehicleBodyHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_engine_damage) || 
-                        GetVehicleEngineHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_body_damage)))
+                        Notify.Error(CommonErrors.NoVehicle);
+                        return;
+                    }
+
+                    bool checkDamageBeforeChangingExtras = GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged);
+
+                    if (checkDamageBeforeChangingExtras)
+                    {
+                        bool isTooDamaged = IsVehicleTooDamagedToChangeExtras(veh);
+
+                        if (isTooDamaged)
                         {
                             // Send message to player when extra change is denied
                             Notify.Alert("Vehicle is too damaged to change extra, repair it first!", true, false);
-                           
-                            // Revert checkbox back to original state
-                            ((MenuCheckboxItem)item).Checked = veh.IsExtraOn(extra);
+
+                            // Send to previous menu
+                            VehicleComponentsMenu.GoBack();
                             return;
                         }
-                        veh.ToggleExtra(extra, _checked);
                     }
+
+                    veh.ToggleExtra(extra, _checked);
                 }
             };
             #endregion
@@ -2441,5 +2496,15 @@ namespace vMenuClient.menus
             return 0;
         }
         #endregion
+
+        private bool IsVehicleTooDamagedToChangeExtras(Vehicle vehicle)
+        {
+            float bodyHealth = vehicle.BodyHealth;
+            float engineHealth = vehicle.EngineHealth;
+            float allowedBodyHealth = GetSettingsInt(Setting.vmenu_allowed_body_damage_for_extra_change);
+            float allowedEngineHealth = GetSettingsInt(Setting.vmenu_allowed_engine_damage_for_extra_change);
+
+            return bodyHealth < allowedBodyHealth || engineHealth < allowedEngineHealth;
+        }
     }
 }

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1702,7 +1702,25 @@ namespace vMenuClient.menus
                 if (vehicleExtras.TryGetValue(item, out var extra))
                 {
                     var veh = GetVehicle();
-                    veh.ToggleExtra(extra, _checked);
+                    if (veh != null && veh.Exists())
+                    {
+                        // If vmenu_prevent_extras_when_damaged is enabled, check vehicle engine and body health
+                        if (GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged) && 
+                        (API.GetVehicleBodyHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_engine_damage) || 
+                        API.GetVehicleEngineHealth(veh.Handle) < GetSettingsInt(Setting.vmenu_prevent_extras_body_damage)))
+                        {
+                            if (GetSettingsBool(Setting.vmenu_prevent_extras_notification_enabled))
+                            {
+                                Screen.ShowNotification(GetSettingsString(Setting.vmenu_prevent_extras_notification_text));
+                            }
+                           
+                            // Revert checkbox back to original state
+                            ((MenuCheckboxItem)item).Checked = veh.IsExtraOn(extra);
+                            return;
+                        }
+
+                        veh.ToggleExtra(extra, _checked);
+                    }
                 }
             };
             #endregion

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 
 using CitizenFX.Core;
+using CitizenFX.Core.Native;
+using CitizenFX.Core.UI;
 
 using MenuAPI;
 

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -140,8 +140,6 @@ setr vmenu_prevent_extras_when_damaged false
 setr vmenu_prevent_extras_engine_damage 800
 # This is the amount of body damage before the extras will be blocked. Value must be between 0 and 1000 (inclusive)
 setr vmenu_prevent_extras_body_damage 800
-# Enabling this will show a notification when the player attempts to modify extras.
-setr vmenu_prevent_extras_notification_enabled true
 
 ### MP Ped options ###
 # Setting this to true will enable a 3D ped preview when viewing saved MP Peds.

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -142,8 +142,6 @@ setr vmenu_prevent_extras_engine_damage 800
 setr vmenu_prevent_extras_body_damage 800
 # Enabling this will show a notification when the player attempts to modify extras.
 setr vmenu_prevent_extras_notification_enabled true
-# This is the message that will be displayed when a player attempts to modify extras when the vehicle is damaged.
-setr vmenu_prevent_extras_notification_text "Vehicle is too damaged. Please visit a mechanic."
 
 ### MP Ped options ###
 # Setting this to true will enable a 3D ped preview when viewing saved MP Peds.

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -133,13 +133,12 @@ setr vmenu_sync_to_machine_time false
 # Setting this to true will enable the chameleon colour vehicle paints category in the primary colours menu.
 # You must be streaming the chameleon colours in order for this to function properly.
 setr vmenu_using_chameleon_colours false
-
 # Setting this to true will prevent players from modifying vehicle extras to repair their vehicle when it is damaged.
 setr vmenu_prevent_extras_when_damaged false
 # This is the amount of engine damage before the extras will be blocked. Value must be between 0 and 1000 (inclusive)
-setr vmenu_prevent_extras_engine_damage 800
+setr vmenu_allowed_engine_damage_for_extra_change 800
 # This is the amount of body damage before the extras will be blocked. Value must be between 0 and 1000 (inclusive)
-setr vmenu_prevent_extras_body_damage 800
+setr vmenu_allowed_body_damage_for_extra_change 800
 
 ### MP Ped options ###
 # Setting this to true will enable a 3D ped preview when viewing saved MP Peds.

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -136,9 +136,9 @@ setr vmenu_using_chameleon_colours false
 
 # Setting this to true will prevent players from modifying vehicle extras to repair their vehicle when it is damaged.
 setr vmenu_prevent_extras_when_damaged false
-# This is the amount of engine damage before the extras will be blocked.
+# This is the amount of engine damage before the extras will be blocked. Value must be between 0 and 1000 (inclusive)
 setr vmenu_prevent_extras_engine_damage 800
-# This is the amount of body damage before the extras will be blocked.
+# This is the amount of body damage before the extras will be blocked. Value must be between 0 and 1000 (inclusive)
 setr vmenu_prevent_extras_body_damage 800
 # Enabling this will show a notification when the player attempts to modify extras.
 setr vmenu_prevent_extras_notification_enabled true

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -134,6 +134,17 @@ setr vmenu_sync_to_machine_time false
 # You must be streaming the chameleon colours in order for this to function properly.
 setr vmenu_using_chameleon_colours false
 
+# Setting this to true will prevent players from modifying vehicle extras to repair their vehicle when it is damaged.
+setr vmenu_prevent_extras_when_damaged false
+# This is the amount of engine damage before the extras will be blocked.
+setr vmenu_prevent_extras_engine_damage 800
+# This is the amount of body damage before the extras will be blocked.
+setr vmenu_prevent_extras_body_damage 800
+# Enabling this will show a notification when the player attempts to modify extras.
+setr vmenu_prevent_extras_notification_enabled true
+# This is the message that will be displayed when a player attempts to modify extras when the vehicle is damaged.
+setr vmenu_prevent_extras_notification_text "Vehicle is too damaged. Please visit a mechanic."
+
 ### MP Ped options ###
 # Setting this to true will enable a 3D ped preview when viewing saved MP Peds.
 setr vmenu_mp_ped_preview true


### PR DESCRIPTION
This is to add the configurable functionality to prevent a player from adding or removing extras on a vehicle in order to repair it.

Config options consist of:
- Enabling the core functionality
- The amount of engine damage that can be tolerated before the extras are blocked
- The amount of body damage that can be tolerated before the extras are blocked
~~- Enabling a notification to the player when they attempt to change extras, but are not permitted~~
~~- The contents of the notification~~