### PR TITLE
Refactors vehicle mod logic to use updated mod type list

### DIFF
--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1534,7 +1534,7 @@ namespace vMenuClient
                     #region new saving method
                     var mods = new Dictionary<int, int>();
 
-                    foreach (var mod in veh.Mods.GetAllMods())
+                    foreach (var mod in GetAllVehicleMods(veh))
                     {
                         mods.Add((int)mod.ModType, mod.Index);
                     }
@@ -3464,6 +3464,27 @@ namespace vMenuClient
             }
             TriggerServerEvent("vMenu:SaveTeleportLocation", JsonConvert.SerializeObject(new vMenuShared.ConfigManager.TeleportLocation(locationName, pos, heading)));
             Notify.Success("The location was successfully saved.");
+        }
+        #endregion
+
+        #region Get all vehicle mods
+        public static VehicleMod[] GetAllVehicleMods(Vehicle vehicle)
+        {
+            int vehicleHandle = vehicle.Handle;
+
+            bool HasVehicleMod(VehicleData.ModType modType)
+            {
+                return GetNumVehicleMods(vehicleHandle, (int)modType) > 0;
+            }
+
+            return
+            [
+                .. Enum.GetValues(typeof(VehicleData.ModType))
+                    .Cast<VehicleData.ModType>()
+                    .Where(HasVehicleMod)
+                    // The cast to `VehicleModType` is fine here because `VehicleMod` casts `VehicleModType` to `int`
+                    .Select(modType => vehicle.Mods[(VehicleModType)modType])
+            ];
         }
         #endregion
     }

--- a/vMenu/data/VehicleData.cs
+++ b/vMenu/data/VehicleData.cs
@@ -1446,5 +1446,62 @@ namespace vMenuClient.data
                 return vehs.ToArray();
             }
         }
+
+        /// <summary>
+        /// Values taken from `SET_VEHICLE_MOD` native
+        /// </summary>
+        public enum ModType
+        {
+            VMT_SPOILER = 0,
+            VMT_BUMPER_F = 1,
+            VMT_BUMPER_R = 2,
+            VMT_SKIRT = 3,
+            VMT_EXHAUST = 4,
+            VMT_CHASSIS = 5,
+            VMT_GRILL = 6,
+            VMT_BONNET = 7,
+            VMT_WING_L = 8,
+            VMT_WING_R = 9,
+            VMT_ROOF = 10,
+            VMT_ENGINE = 11,
+            VMT_BRAKES = 12,
+            VMT_GEARBOX = 13,
+            VMT_HORN = 14,
+            VMT_SUSPENSION = 15,
+            VMT_ARMOUR = 16,
+            VMT_NITROUS = 17,
+            VMT_TURBO = 18,
+            VMT_SUBWOOFER = 19,
+            VMT_TYRE_SMOKE = 20,
+            VMT_HYDRAULICS = 21,
+            VMT_XENON_LIGHTS = 22,
+            VMT_WHEELS = 23,
+            VMT_WHEELS_REAR_OR_HYDRAULICS = 24,
+            VMT_PLTHOLDER = 25,
+            VMT_PLTVANITY = 26,
+            VMT_INTERIOR1 = 27,
+            VMT_INTERIOR2 = 28,
+            VMT_INTERIOR3 = 29,
+            VMT_INTERIOR4 = 30,
+            VMT_INTERIOR5 = 31,
+            VMT_SEATS = 32,
+            VMT_STEERING = 33,
+            VMT_KNOB = 34,
+            VMT_PLAQUE = 35,
+            VMT_ICE = 36,
+            VMT_TRUNK = 37,
+            VMT_HYDRO = 38,
+            VMT_ENGINEBAY1 = 39,
+            VMT_ENGINEBAY2 = 40,
+            VMT_ENGINEBAY3 = 41,
+            VMT_CHASSIS2 = 42,
+            VMT_CHASSIS3 = 43,
+            VMT_CHASSIS4 = 44,
+            VMT_CHASSIS5 = 45,
+            VMT_DOOR_L = 46,
+            VMT_DOOR_R = 47,
+            VMT_LIVERY_MOD = 48,
+            VMT_LIGHTBAR = 49,
+        }
     }
 }

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1946,7 +1946,7 @@ namespace vMenuClient.menus
                 SetVehicleModKit(veh.Handle, 0);
 
                 // Get all mods available on this vehicle.
-                var mods = veh.Mods.GetAllMods();
+                var mods = GetAllVehicleMods(veh);
 
                 // Loop through all the mods.
                 foreach (var mod in mods)


### PR DESCRIPTION
Calling `.GetAllMods()` checked against `VehicleModType` internally, which was missing values 47 and 49 (as well as most values being named incorrectly). This commit provides an up-to-date mod type list and gets vehicle mods based on said list.


Fixes #302 