### PR TITLE
Fix MP Blending

### DIFF
--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -1020,13 +1020,14 @@ namespace vMenuClient.menus
 
             var inheritanceDads = new MenuListItem("Father", dads.Keys.ToList(), 0, "Select a father.");
             var inheritanceMoms = new MenuListItem("Mother", moms.Keys.ToList(), 0, "Select a mother.");
-            var inheritanceShapeMix = new MenuSliderItem("Head Shape Mix", "Select how much of your head shape should be inherited from your father or mother. All the way on the left is your dad, all the way on the right is your mom.", 0, 10, 5, true) { SliderLeftIcon = MenuItem.Icon.MALE, SliderRightIcon = MenuItem.Icon.FEMALE };
-            var inheritanceSkinMix = new MenuSliderItem("Body Skin Mix", "Select how much of your body skin tone should be inherited from your father or mother. All the way on the left is your dad, all the way on the right is your mom.", 0, 10, 5, true) { SliderLeftIcon = MenuItem.Icon.MALE, SliderRightIcon = MenuItem.Icon.FEMALE };
+            var inheritanceShapeMix = new MenuSliderItem("Head Shape Mix", "Select how much of your head shape should be inherited from your father or mother. All the way on the left is your dad, all the way on the right is your mom.", -10, 10, 0, true) { SliderLeftIcon = MenuItem.Icon.MALE, SliderRightIcon = MenuItem.Icon.FEMALE };
+            var inheritanceSkinMix = new MenuSliderItem("Body Skin Mix", "Select how much of your body skin tone should be inherited from your father or mother. All the way on the left is your dad, all the way on the right is your mom.", -10, 10, 0, true) { SliderLeftIcon = MenuItem.Icon.MALE, SliderRightIcon = MenuItem.Icon.FEMALE };
 
             inheritanceMenu.AddMenuItem(inheritanceDads);
             inheritanceMenu.AddMenuItem(inheritanceMoms);
             inheritanceMenu.AddMenuItem(inheritanceShapeMix);
             inheritanceMenu.AddMenuItem(inheritanceSkinMix);
+
 
             // formula from maintransition.#sc
             float GetMinimum()
@@ -1067,9 +1068,8 @@ namespace vMenuClient.menus
 
             inheritanceMenu.OnSliderPositionChange += (sender, item, oldPosition, newPosition, itemIndex) =>
             {
-                _shapeMixValue = inheritanceShapeMix.Position;
-                _skinMixValue = inheritanceSkinMix.Position;
-
+                _shapeMixValue = ((float)inheritanceShapeMix.Position) / 10.0f ;
+                _skinMixValue = ((float)inheritanceSkinMix.Position) / 10.0f;
                 SetHeadBlend();
             };
             #endregion
@@ -1772,8 +1772,9 @@ namespace vMenuClient.menus
                 {
                     _dadSelection = _random.Next(parents.Count);
                     _mumSelection = _random.Next(parents.Count);
-                    _skinMixValue = _random.Next(2, 8);
-                    _shapeMixValue = _random.Next(2, 8);
+                    // These equations are needed to get random float values
+                    _skinMixValue = (float)(_random.NextDouble() * 2 -1) * 10.0f;
+                    _shapeMixValue = (float)(_random.NextDouble() * 2 - 1) * 10.0f;
 
                     SetHeadBlend();
 

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -1,4 +1,4 @@
-using System;
+_using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -1773,8 +1773,8 @@ namespace vMenuClient.menus
                     _dadSelection = _random.Next(parents.Count);
                     _mumSelection = _random.Next(parents.Count);
                     // These equations are needed to get random float values
-                    _skinMixValue = (float)(_random.NextDouble() * 2 -1) * 10.0f;
-                    _shapeMixValue = (float)(_random.NextDouble() * 2 - 1) * 10.0f;
+                    _skinMixValue = (float)_random.NextDouble() * 2 -1 * 10.0f;
+                    _shapeMixValue = (float)_random.NextDouble() * 2 - 1 * 10.0f;
 
                     SetHeadBlend();
 

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -151,6 +151,10 @@ namespace vMenuClient.menus
                 currentCharacter.ModelHash = male ? (uint)GetHashKey("mp_m_freemode_01") : (uint)GetHashKey("mp_f_freemode_01");
                 currentCharacter.IsMale = male;
 
+                // Places the sliders in the middle by default
+                _shapeMixValue = 0.5f;
+                _skinMixValue = 0.5f;
+
                 SetPlayerClothing();
             }
             currentCharacter.DrawableVariations.clothes ??= new Dictionary<int, KeyValuePair<int, int>>();
@@ -1020,14 +1024,13 @@ namespace vMenuClient.menus
 
             var inheritanceDads = new MenuListItem("Father", dads.Keys.ToList(), 0, "Select a father.");
             var inheritanceMoms = new MenuListItem("Mother", moms.Keys.ToList(), 0, "Select a mother.");
-            var inheritanceShapeMix = new MenuSliderItem("Head Shape Mix", "Select how much of your head shape should be inherited from your father or mother. All the way on the left is your dad, all the way on the right is your mom.", -10, 10, 0, true) { SliderLeftIcon = MenuItem.Icon.MALE, SliderRightIcon = MenuItem.Icon.FEMALE };
-            var inheritanceSkinMix = new MenuSliderItem("Body Skin Mix", "Select how much of your body skin tone should be inherited from your father or mother. All the way on the left is your dad, all the way on the right is your mom.", -10, 10, 0, true) { SliderLeftIcon = MenuItem.Icon.MALE, SliderRightIcon = MenuItem.Icon.FEMALE };
+            var inheritanceShapeMix = new MenuSliderItem("Head Shape Mix", "Select how much of your head shape should be inherited from your father or mother. All the way on the left is your dad, all the way on the right is your mom.", 0, 10, 5, true) { SliderLeftIcon = MenuItem.Icon.MALE, SliderRightIcon = MenuItem.Icon.FEMALE, ItemData = "shape_mix" };
+            var inheritanceSkinMix = new MenuSliderItem("Body Skin Mix", "Select how much of your body skin tone should be inherited from your father or mother. All the way on the left is your dad, all the way on the right is your mom.", 0, 10, 5, true) { SliderLeftIcon = MenuItem.Icon.MALE, SliderRightIcon = MenuItem.Icon.FEMALE, ItemData = "skin_mix" };
 
             inheritanceMenu.AddMenuItem(inheritanceDads);
             inheritanceMenu.AddMenuItem(inheritanceMoms);
             inheritanceMenu.AddMenuItem(inheritanceShapeMix);
             inheritanceMenu.AddMenuItem(inheritanceSkinMix);
-
 
             // formula from maintransition.#sc
             float GetMinimum()
@@ -1068,9 +1071,21 @@ namespace vMenuClient.menus
 
             inheritanceMenu.OnSliderPositionChange += (sender, item, oldPosition, newPosition, itemIndex) =>
             {
-                // Converts the position to a float which is required by the Native
-                _shapeMixValue = (float)inheritanceShapeMix.Position;
-                _skinMixValue = (float)inheritanceSkinMix.Position;
+                // Chris: We can't call `.Position` on the slider items here because it returns the value *prior* to the change
+                switch (item.ItemData)
+                {
+                    case "shape_mix":
+                        _shapeMixValue = newPosition / 10f;
+                        break;
+
+                    case "skin_mix":
+                        _skinMixValue = newPosition / 10f;
+                        break;
+
+                    default:
+                        break;
+                }
+
                 SetHeadBlend();
             };
             #endregion
@@ -1773,9 +1788,8 @@ namespace vMenuClient.menus
                 {
                     _dadSelection = _random.Next(parents.Count);
                     _mumSelection = _random.Next(parents.Count);
-                    // These equations are needed to get random float values
-                    _skinMixValue = (float)_random.NextDouble() * 10.0f;
-                    _shapeMixValue = (float)_random.NextDouble() * 10.0f;
+                    _skinMixValue = (float)_random.NextDouble();
+                    _shapeMixValue = (float)_random.NextDouble();
 
                     SetHeadBlend();
 
@@ -1982,8 +1996,8 @@ namespace vMenuClient.menus
                 {
                     inheritanceDads.ListIndex = _dadSelection;
                     inheritanceMoms.ListIndex = _mumSelection;
-                    inheritanceShapeMix.Position = (int)_shapeMixValue;
-                    inheritanceSkinMix.Position = (int)_skinMixValue;
+                    inheritanceShapeMix.Position = (int)(_shapeMixValue * 10f);
+                    inheritanceSkinMix.Position = (int)(_skinMixValue * 10f);
                     inheritanceMenu.RefreshIndex();
                 }
                 else if (item == faceButton)
@@ -3016,10 +3030,7 @@ namespace vMenuClient.menus
 
         internal void SetHeadBlend()
         {
-            // Scales down from 10 then clamps the value between 0.0f - 1.0f and assigns to _shape/skinValue to prevent menu from breaking
-            float _shapeValue = (((_shapeMixValue) / 10.0f) + 1) / 2;
-            float _skinValue = (((_skinMixValue) / 10.0f) + 1) / 2;
-            SetPedHeadBlendData(Game.PlayerPed.Handle, _dadSelection, _mumSelection, 0, _dadSelection, _mumSelection, 0, _shapeValue, _skinValue, 0f, false);
+            SetPedHeadBlendData(Game.PlayerPed.Handle, _dadSelection, _mumSelection, 0, _dadSelection, _mumSelection, 0, _shapeMixValue, _skinMixValue, 0f, false);
         }
 
         internal void ChangePlayerHair(int newHairIndex)

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -1773,8 +1773,8 @@ namespace vMenuClient.menus
                     _dadSelection = _random.Next(parents.Count);
                     _mumSelection = _random.Next(parents.Count);
                     // These equations are needed to get random float values
-                    _skinMixValue = (float)_random.NextDouble() * 2 -1 * 10.0f;
-                    _shapeMixValue = (float)_random.NextDouble() * 2 - 1 * 10.0f;
+                    _skinMixValue = ((float)_random.NextDouble() * 2 -1) * 10.0f;
+                    _shapeMixValue = ((float)_random.NextDouble() * 2 - 1) * 10.0f;
 
                     SetHeadBlend();
 

--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -1,4 +1,4 @@
-_using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -1068,8 +1068,9 @@ namespace vMenuClient.menus
 
             inheritanceMenu.OnSliderPositionChange += (sender, item, oldPosition, newPosition, itemIndex) =>
             {
-                _shapeMixValue = ((float)inheritanceShapeMix.Position) / 10.0f ;
-                _skinMixValue = ((float)inheritanceSkinMix.Position) / 10.0f;
+                // Converts the position to a float which is required by the Native
+                _shapeMixValue = (float)inheritanceShapeMix.Position;
+                _skinMixValue = (float)inheritanceSkinMix.Position;
                 SetHeadBlend();
             };
             #endregion
@@ -1773,8 +1774,8 @@ namespace vMenuClient.menus
                     _dadSelection = _random.Next(parents.Count);
                     _mumSelection = _random.Next(parents.Count);
                     // These equations are needed to get random float values
-                    _skinMixValue = ((float)_random.NextDouble() * 2 -1) * 10.0f;
-                    _shapeMixValue = ((float)_random.NextDouble() * 2 - 1) * 10.0f;
+                    _skinMixValue = (float)_random.NextDouble() * 10.0f;
+                    _shapeMixValue = (float)_random.NextDouble() * 10.0f;
 
                     SetHeadBlend();
 
@@ -3015,7 +3016,10 @@ namespace vMenuClient.menus
 
         internal void SetHeadBlend()
         {
-            SetPedHeadBlendData(Game.PlayerPed.Handle, _dadSelection, _mumSelection, 0, _dadSelection, _mumSelection, 0, _shapeMixValue, _skinMixValue, 0f, false);
+            // Scales down from 10 then clamps the value between 0.0f - 1.0f and assigns to _shape/skinValue to prevent menu from breaking
+            float _shapeValue = (((_shapeMixValue) / 10.0f) + 1) / 2;
+            float _skinValue = (((_skinMixValue) / 10.0f) + 1) / 2;
+            SetPedHeadBlendData(Game.PlayerPed.Handle, _dadSelection, _mumSelection, 0, _dadSelection, _mumSelection, 0, _shapeValue, _skinValue, 0f, false);
         }
 
         internal void ChangePlayerHair(int newHairIndex)


### PR DESCRIPTION
Fixes:
https://github.com/TomGrobbe/vMenu/issues/511

I looked at the native [`SET_PED_HEAD_BLEND_DATA`](https://docs.fivem.net/natives/?_0x9414E18B9434C2FE) and noticed it needed a `float` for blend data but `MenuSliderItem.Position` is an `int` so all I did was make the minimum slider value -10 and the max +10 meaning you can have values `-10`-`10` which is then converted to a float ranging from `-1`-`1` by dividing it by 10 which gives values like `0.9` and `-0.2`. I also edited the randomize feature to fix this logic.

To understand why there needs to be negative values is if its closer to `-1` the blend for the dad and for `1` its the mom