### PR TITLE
Fixes custom vehicle RGB colors being saved erroneously

### DIFF
--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1574,17 +1574,32 @@ namespace vMenuClient
                     colors.Add("tyresmokeR", tyresmokeR);
                     colors.Add("tyresmokeG", tyresmokeG);
                     colors.Add("tyresmokeB", tyresmokeB);
+
                     int customPrimaryR = -1;
                     int customPrimaryG = -1;
                     int customPrimaryB = -1;
-                    GetVehicleCustomPrimaryColour(veh.Handle, ref customPrimaryR, ref customPrimaryG, ref customPrimaryB);
+                    bool primaryColorIsCustom = GetIsVehiclePrimaryColourCustom(veh.Handle);
+
+                    if (primaryColorIsCustom)
+                    {
+                        GetVehicleCustomPrimaryColour(veh.Handle, ref customPrimaryR, ref customPrimaryG, ref customPrimaryB);
+                    }
+                    
                     colors.Add("customPrimaryR", customPrimaryR);
                     colors.Add("customPrimaryG", customPrimaryG);
                     colors.Add("customPrimaryB", customPrimaryB);
+
                     int customSecondaryR = -1;
                     int customSecondaryG = -1;
                     int customSecondaryB = -1;
-                    GetVehicleCustomSecondaryColour(veh.Handle, ref customSecondaryR, ref customSecondaryG, ref customSecondaryB);
+
+                    bool secondaryColorIsCustom = GetIsVehicleSecondaryColourCustom(veh.Handle);
+
+                    if (secondaryColorIsCustom)
+                    {
+                        GetVehicleCustomSecondaryColour(veh.Handle, ref customSecondaryR, ref customSecondaryG, ref customSecondaryB);
+                    }
+
                     colors.Add("customSecondaryR", customSecondaryR);
                     colors.Add("customSecondaryG", customSecondaryG);
                     colors.Add("customSecondaryB", customSecondaryB);

--- a/vMenu/menus/SavedVehicles.cs
+++ b/vMenu/menus/SavedVehicles.cs
@@ -499,7 +499,7 @@ namespace vMenuClient.menus
                             replaceButtonPressedCount = 0;
                             item.Label = "";
                             SaveVehicle(currentlySelectedVehicle.Key.Substring(4), currentlySelectedVehicle.Value.Category);
-                            selectedVehicleMenu.GoBack();
+                            selectedVehicleMenu.CloseMenu();
                             Notify.Success("Your saved vehicle has been replaced with your current vehicle.");
                         }
                     }


### PR DESCRIPTION
Also kicks players out of the saved vehicle menu after they replace a vehicle, since the saved vehicle data is stored in the item data of each menu item, so if the player spawns a saved vehicle right after replacing it, it actually spawns the prior version - kicking them out of the menu forces the menu to be recreated, and pull the latest version of the saved vehicle.

Fixed #456.