### PR TITLE
Fixes blackout for vehicle lights not syncing between clients

### DIFF
--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -2044,9 +2044,12 @@ namespace vMenuClient
         /// Update the server with the new weather type, blackout status and dynamic weather changes enabled status.
         /// </summary>
         /// <param name="newWeather">The new weather type.</param>
-        /// <param name="blackout">Manual blackout mode enabled/disabled.</param>
         /// <param name="dynamicChanges">Dynamic weather changes enabled/disabled.</param>
-        public static void UpdateServerWeather(string newWeather, bool blackout, bool dynamicChanges, bool isSnowEnabled) => TriggerServerEvent("vMenu:UpdateServerWeather", newWeather, blackout, dynamicChanges, isSnowEnabled);
+        public static void UpdateServerWeather(string newWeather, bool dynamicChanges, bool isSnowEnabled) => TriggerServerEvent("vMenu:UpdateServerWeather", newWeather, dynamicChanges, isSnowEnabled);
+
+        public static void UpdateServerBlackout(bool value) => TriggerServerEvent("vMenu:UpdateServerBlackout", value);
+
+        public static void UpdateServerVehicleBlackout(bool value) => TriggerServerEvent("vMenu:UpdateServerVehicleBlackout", value);
 
         /// <summary>
         /// Modify the clouds for everyone. If removeClouds is true, then remove all clouds. If it's false, then randomize the clouds.

--- a/vMenu/EventManager.cs
+++ b/vMenu/EventManager.cs
@@ -28,7 +28,7 @@ namespace vMenuClient
         public static string GetServerWeather => GetSettingsString(Setting.vmenu_current_weather, "CLEAR");
         public static bool DynamicWeatherEnabled => GetSettingsBool(Setting.vmenu_enable_dynamic_weather);
         public static bool IsBlackoutEnabled => GetSettingsBool(Setting.vmenu_blackout_enabled);
-        public static bool IsVehicleLightsEnabled { get; set; } = GetSettingsBool(Setting.vmenu_vehicle_blackout_enabled);
+        public static bool IsVehicleLightsEnabled => GetSettingsBool(Setting.vmenu_vehicle_blackout_enabled);
         public static int WeatherChangeTime => MathUtil.Clamp(GetSettingsInt(Setting.vmenu_weather_change_duration), 0, 45);
 
         /// <summary>

--- a/vMenu/menus/WeatherOptions.cs
+++ b/vMenu/menus/WeatherOptions.cs
@@ -45,7 +45,7 @@ namespace vMenuClient.menus
 
             dynamicWeatherEnabled = new MenuCheckboxItem("Toggle Dynamic Weather", "Enable or disable dynamic weather changes.", EventManager.DynamicWeatherEnabled);
             blackout = new MenuCheckboxItem("Toggle Blackout", "This disables or enables all lights across the map.", EventManager.IsBlackoutEnabled);
-            vehicleBlackout = new MenuCheckboxItem("Toggle Vehicle Lights Blackout", "This disables or enables all vehicle lights across the map.", EventManager.IsVehicleLightsEnabled);
+            vehicleBlackout = new MenuCheckboxItem("Toggle Vehicle Lights Blackout", "This disables or enables all vehicle lights across the map.", !EventManager.IsVehicleLightsEnabled);
             snowEnabled = new MenuCheckboxItem("Enable Snow Effects", "This will force snow to appear on the ground and enable snow particle effects for peds and vehicles. Combine with X-MAS or Light Snow weather for best results.", ConfigManager.GetSettingsBool(ConfigManager.Setting.vmenu_enable_snow));
             
             var extrasunny = new MenuItem("Extra Sunny", "Set the weather to ~y~extra sunny~s~!") { ItemData = "EXTRASUNNY" };
@@ -120,7 +120,7 @@ namespace vMenuClient.menus
                 else if (item.ItemData is string weatherType)
                 {
                     Notify.Custom($"The weather will be changed to ~y~{item.Text}~s~. This will take {EventManager.WeatherChangeTime} seconds.");
-                    UpdateServerWeather(weatherType, EventManager.IsBlackoutEnabled, EventManager.DynamicWeatherEnabled, EventManager.IsSnowEnabled);
+                    UpdateServerWeather(weatherType, EventManager.DynamicWeatherEnabled, EventManager.IsSnowEnabled);
                 }
             };
 
@@ -129,22 +129,22 @@ namespace vMenuClient.menus
                 if (item == dynamicWeatherEnabled)
                 {
                     Notify.Custom($"Dynamic weather changes are now {(_checked ? "~g~enabled" : "~r~disabled")}~s~.");
-                    UpdateServerWeather(EventManager.GetServerWeather, EventManager.IsBlackoutEnabled, _checked, EventManager.IsSnowEnabled);
+                    UpdateServerWeather(EventManager.GetServerWeather, _checked, EventManager.IsSnowEnabled);
                 }
                 else if (item == blackout)
                 {
                     Notify.Custom($"Blackout mode is now {(_checked ? "~g~enabled" : "~r~disabled")}~s~.");
-                    UpdateServerWeather(EventManager.GetServerWeather, _checked , EventManager.DynamicWeatherEnabled,  EventManager.IsSnowEnabled);
+                    UpdateServerBlackout(_checked);
                 }
                 else if (item == vehicleBlackout)
                 {
-                    Notify.Custom($"Vehicle lights mode is now {(_checked ? "~g~enabled" : "~r~disabled")}~s~.");
-                    EventManager.IsVehicleLightsEnabled = _checked;
+                    Notify.Custom($"Vehicle light blackout mode is now {(_checked ? "~g~enabled" : "~r~disabled")}~s~.");
+                    UpdateServerVehicleBlackout(!_checked);
                 }
                 else if (item == snowEnabled)
                 {
                     Notify.Custom($"Snow effects will now be forced {(_checked ? "~g~enabled" : "~r~disabled")}~s~.");
-                    UpdateServerWeather(EventManager.GetServerWeather, EventManager.IsBlackoutEnabled, EventManager.DynamicWeatherEnabled, _checked);
+                    UpdateServerWeather(EventManager.GetServerWeather, EventManager.DynamicWeatherEnabled, _checked);
                 }
             };
         }

--- a/vMenuServer/MainServer.cs
+++ b/vMenuServer/MainServer.cs
@@ -133,6 +133,11 @@ namespace vMenuServer
             get { return GetSettingsBool(Setting.vmenu_blackout_enabled); }
             set { SetConvarReplicated(Setting.vmenu_blackout_enabled.ToString(), value.ToString().ToLower()); }
         }
+        private bool VehicleBlackoutEnabled
+        {
+            get { return GetSettingsBool(Setting.vmenu_vehicle_blackout_enabled); }
+            set { SetConvarReplicated(Setting.vmenu_vehicle_blackout_enabled.ToString(), value.ToString().ToLower()); }
+        }
         private int DynamicWeatherMinutes
         {
             get { return Math.Max(GetSettingsInt(Setting.vmenu_dynamic_weather_timer), 1); }
@@ -321,7 +326,7 @@ namespace vMenuServer
                             var wtype = args[1].ToString().ToUpper();
                             if (WeatherTypes.Contains(wtype))
                             {
-                                TriggerEvent("vMenu:UpdateServerWeather", wtype, BlackoutEnabled, DynamicWeatherEnabled, ManualSnowEnabled);
+                                TriggerEvent("vMenu:UpdateServerWeather", wtype, DynamicWeatherEnabled, ManualSnowEnabled);
                                 Debug.WriteLine($"[vMenu] Weather is now set to: {wtype}");
                             }
                             else if (wtype.ToLower() == "dynamic")
@@ -330,12 +335,12 @@ namespace vMenuServer
                                 {
                                     if ((args[2].ToString().ToLower() ?? $"{DynamicWeatherEnabled}") == "true")
                                     {
-                                        TriggerEvent("vMenu:UpdateServerWeather", CurrentWeather, BlackoutEnabled, true, ManualSnowEnabled);
+                                        TriggerEvent("vMenu:UpdateServerWeather", CurrentWeather, true, ManualSnowEnabled);
                                         Debug.WriteLine("[vMenu] Dynamic weather is now turned on.");
                                     }
                                     else if ((args[2].ToString().ToLower() ?? $"{DynamicWeatherEnabled}") == "false")
                                     {
-                                        TriggerEvent("vMenu:UpdateServerWeather", CurrentWeather, BlackoutEnabled, false, ManualSnowEnabled);
+                                        TriggerEvent("vMenu:UpdateServerWeather", CurrentWeather, false, ManualSnowEnabled);
                                         Debug.WriteLine("[vMenu] Dynamic weather is now turned off.");
                                     }
                                     else
@@ -669,10 +674,9 @@ namespace vMenuServer
         /// Update the weather for all clients.
         /// </summary>
         /// <param name="newWeather"></param>
-        /// <param name="blackoutNew"></param>
         /// <param name="dynamicWeatherNew"></param>
         [EventHandler("vMenu:UpdateServerWeather")]
-        internal void UpdateWeather([FromSource] Player source, string newWeather, bool blackoutNew, bool dynamicWeatherNew, bool enableSnow)
+        internal void UpdateWeather([FromSource] Player source, string newWeather, bool dynamicWeatherNew, bool enableSnow)
         {
             if (!PermissionsManager.IsAllowed(PermissionsManager.Permission.WOSetWeather, source) && !PermissionsManager.IsAllowed(PermissionsManager.Permission.WOAll, source))
             {
@@ -688,12 +692,35 @@ namespace vMenuServer
 
             // Update the new weather related variables.
             CurrentWeather = newWeather;
-            BlackoutEnabled = blackoutNew;
             DynamicWeatherEnabled = dynamicWeatherNew;
             ManualSnowEnabled = enableSnow;
 
             // Reset the dynamic weather loop timer to another (default) 10 mintues.
             lastWeatherChange = GetGameTimer();
+        }
+
+        [EventHandler("vMenu:UpdateServerBlackout")]
+        internal void UpdateBlackout([FromSource] Player source, bool value)
+        {
+            if (!PermissionsManager.IsAllowed(PermissionsManager.Permission.WOBlackout, source) && !PermissionsManager.IsAllowed(PermissionsManager.Permission.WOAll, source))
+            {
+                BanManager.BanCheater(source);
+                return;
+            }
+
+            BlackoutEnabled = value;
+        }
+
+        [EventHandler("vMenu:UpdateServerVehicleBlackout")]
+        internal void UpdateVehicleBlackout([FromSource] Player source, bool value)
+        {
+            if (!PermissionsManager.IsAllowed(PermissionsManager.Permission.WOVehBlackout, source) && !PermissionsManager.IsAllowed(PermissionsManager.Permission.WOAll, source))
+            {
+                BanManager.BanCheater(source);
+                return;
+            }
+
+            VehicleBlackoutEnabled = value;
         }
 
         /// <summary>


### PR DESCRIPTION
Adds syncing of vehicle light blackout across all clients by adding a server event for it. Also separates the regular blackout option into its own event.

Fixes #502.