### PR TITLE
Adds bypass permissions for damage check before extra change

### DIFF
--- a/SharedClasses/PermissionsManager.cs
+++ b/SharedClasses/PermissionsManager.cs
@@ -105,6 +105,7 @@ namespace vMenuShared
             VOInfiniteFuel,
             VOFlares,
             VOPlaneBombs,
+            VOBypassExtraDamage,
             #endregion
 
             // Vehicle Spawner

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -1699,7 +1699,7 @@ namespace vMenuClient.menus
             VehicleComponentsMenu.OnMenuOpen += (menu) =>
             {
                 Vehicle vehicle;
-                bool checkDamageBeforeChangingExtras = GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged);
+                bool checkDamageBeforeChangingExtras = GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged) && !IsAllowed(Permission.VOBypassExtraDamage);
 
                 if (!checkDamageBeforeChangingExtras || !Entity.Exists(vehicle = GetVehicle()))
                 {
@@ -1755,7 +1755,7 @@ namespace vMenuClient.menus
                         return;
                     }
 
-                    bool checkDamageBeforeChangingExtras = GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged);
+                    bool checkDamageBeforeChangingExtras = GetSettingsBool(Setting.vmenu_prevent_extras_when_damaged) && !IsAllowed(Permission.VOBypassExtraDamage);
 
                     if (checkDamageBeforeChangingExtras)
                     {

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -291,6 +291,7 @@ add_ace builtin.everyone "vMenu.VehicleOptions.All" allow
 #add_ace builtin.everyone "vMenu.VehicleOptions.InfiniteFuel" allow
 #add_ace builtin.everyone "vMenu.VehicleOptions.VOFlares" allow
 #add_ace builtin.everyone "vMenu.VehicleOptions.VOPlaneBombs" allow
+#add_ace group.moderator "vMenu.VehicleOptions.BypassExtraDamage" allow
 
 ####################################
 #       VEHICLE SPAWNER MENU       #


### PR DESCRIPTION
Addresses feedback from the pre-release that moderators/admins should have the option to bypass the damage check that disallows extra changing on vehicles.