### PR TITLE
MP Ped customization fixes

### DIFF
--- a/vMenu/menus/MpPedCustomization.cs
+++ b/vMenu/menus/MpPedCustomization.cs
@@ -768,8 +768,19 @@ namespace vMenuClient.menus
             List<MenuItem.Icon> categoryIcons = GetCategoryIcons(categoryNames);
 
             categoryBtn.ItemData = new Tuple<List<string>, List<MenuItem.Icon>>(categoryNames, categoryIcons);
-            categoryBtn.ListItems = categoryNames;
-            categoryBtn.ListIndex = 0;
+            categoryBtn.ListItems = categoryNames;            
+
+            if (editPed)
+            {
+                int characterCategoryIndex = categoryNames.IndexOf(currentCharacter.Category);
+
+                categoryBtn.ListIndex = characterCategoryIndex;
+            }
+            else
+            {
+                categoryBtn.ListIndex = 0;
+            }
+
             categoryBtn.RightIcon = categoryIcons[categoryBtn.ListIndex];
 
             createCharacterMenu.RefreshIndex();


### PR DESCRIPTION
This PR addresses the following:

1. Fixes #527 by addressing a regression introduced in #515 where the head blend data of saved peds would be reset when editing.
2. Checks and corrects out-of-range saved shape and skin mix values when editing peds.
3. Fixes and refactors logic that handles saved ped appearance values (hair, eye color, etc.).
4. Fixes saved MP Ped's category not being displayed in the MP Ped editor menu.