### PR TITLE
feat: exports

### DIFF
--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using CitizenFX.Core;
 using MenuAPI;
 using Newtonsoft.Json;
-using static vMenuShared.PermissionsManager;
-using static vMenuShared.ConfigManager;
 
 namespace vMenuClient
 {
@@ -401,7 +399,6 @@ namespace vMenuClient
             // Menu Information
             Exports.Add("GetAllMenuIds", new Func<string[]>(GetAllMenuIds));
             Exports.Add("GetMenu", new Func<string, object>(GetMenuExport));
-            Exports.Add("IsMenuPermitted", new Func<string, bool>(IsMenuPermittedExport));
 
             // Ready State Management
             Exports.Add("OnReady", new Action<object>(OnReadyExport));
@@ -1036,30 +1033,6 @@ namespace vMenuClient
         }
 
         /// <summary>
-        /// Export function to check if a menu is permitted based on vMenu permissions
-        /// </summary>
-        /// <param name="menuId">Menu identifier</param>
-        /// <returns>True if permitted, false otherwise</returns>
-        private bool IsMenuPermittedExport(string menuId)
-        {
-            if (string.IsNullOrEmpty(menuId))
-            {
-                return false;
-            }
-
-            var normalizedId = menuId.ToLower().Replace(" ", "-");
-
-            // Get the menu to check if it exists
-            var menu = GetMenu(normalizedId);
-            if (menu == null)
-            {
-                return false;
-            }
-
-            return IsMenuPermitted(menu, normalizedId);
-        }
-
-        /// <summary>
         /// Registers a callback to be invoked when vMenu is ready
         /// If vMenu is already ready, the callback is invoked immediately
         /// Note: Callbacks that perform asynchronous work (menu modifications, waits, etc.)
@@ -1117,165 +1090,6 @@ namespace vMenuClient
 
             // Clear the callbacks list
             ReadyCallbacks.Clear();
-        }
-
-        /// <summary>
-        /// Checks if a menu is permitted based on vMenu permissions
-        /// </summary>
-        /// <param name="menu">Menu to check</param>
-        /// <param name="menuId">Menu identifier</param>
-        /// <returns>True if permitted, false otherwise</returns>
-        private bool IsMenuPermitted(Menu menu, string menuId)
-        {
-            // Check direct menu mappings first
-            if (IsDirectMenuMapping(menuId, out bool permitted))
-            {
-                return permitted;
-            }
-
-            // Check pattern-based menus
-            if (IsPatternBasedMenu(menuId, out permitted))
-            {
-                return permitted;
-            }
-
-            // Check unrestricted menus
-            if (IsUnrestrictedMenu(menuId))
-            {
-                return true;
-            }
-
-            // Default to allowing access for unrecognized menus
-            return true;
-        }
-
-        /// <summary>
-        /// Checks direct menu ID mappings to permissions
-        /// </summary>
-        private bool IsDirectMenuMapping(string menuId, out bool permitted)
-        {
-            permitted = false;
-
-            switch (menuId)
-            {
-                case "player-options":
-                    permitted = IsAllowed(Permission.POMenu);
-                    return true;
-                case "online-players":
-                    permitted = IsAllowed(Permission.OPMenu);
-                    return true;
-                case "personal-vehicle-options":
-                    permitted = IsAllowed(Permission.PVMenu);
-                    return true;
-                case "vehicle-options":
-                    permitted = IsAllowed(Permission.VOMenu);
-                    return true;
-                case "vehicle-spawner":
-                    permitted = IsAllowed(Permission.VSMenu);
-                    return true;
-                case "weapon-options":
-                    permitted = IsAllowed(Permission.WPMenu);
-                    return true;
-                case "voice-chat-settings":
-                    permitted = IsAllowed(Permission.VCMenu);
-                    return true;
-                case "player-appearance":
-                case "character-appearance-options":
-                case "mp-ped-customization":
-                    permitted = IsAllowed(Permission.PAMenu);
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        /// <summary>
-        /// Checks pattern-based menu permissions (menus with dynamic IDs)
-        /// </summary>
-        private bool IsPatternBasedMenu(string menuId, out bool permitted)
-        {
-            permitted = false;
-
-            if (menuId.Contains("banned-players"))
-            {
-                permitted = IsBannedPlayersMenuPermitted();
-                return true;
-            }
-
-            if (menuId.Contains("saved") && menuId.Contains("vehicle"))
-            {
-                permitted = IsAllowed(Permission.SVMenu);
-                return true;
-            }
-
-            if (menuId.Contains("weapon-loadouts"))
-            {
-                permitted = IsAllowed(Permission.WLMenu);
-                return true;
-            }
-
-            if (menuId.Contains("time"))
-            {
-                permitted = IsTimeMenuPermitted();
-                return true;
-            }
-
-            if (menuId.Contains("weather"))
-            {
-                permitted = IsWeatherMenuPermitted();
-                return true;
-            }
-
-            if (menuId == "world" || menuId.Contains("world"))
-            {
-                permitted = IsWorldMenuPermitted();
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Checks if a menu is unrestricted (always accessible)
-        /// </summary>
-        private bool IsUnrestrictedMenu(string menuId)
-        {
-            return menuId.Contains("recording-options") ||
-                   menuId.Contains("misc-settings") ||
-                   menuId.Contains("about-vmenu");
-        }
-
-        /// <summary>
-        /// Checks if the banned players menu is permitted
-        /// </summary>
-        private bool IsBannedPlayersMenuPermitted()
-        {
-            return IsAllowed(Permission.OPUnban) || IsAllowed(Permission.OPViewBannedPlayers);
-        }
-
-        /// <summary>
-        /// Checks if the time menu is permitted
-        /// </summary>
-        private bool IsTimeMenuPermitted()
-        {
-            return IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync);
-        }
-
-        /// <summary>
-        /// Checks if the weather menu is permitted
-        /// </summary>
-        private bool IsWeatherMenuPermitted()
-        {
-            return IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync);
-        }
-
-        /// <summary>
-        /// Checks if the world menu is permitted (requires time or weather permissions)
-        /// </summary>
-        private bool IsWorldMenuPermitted()
-        {
-            return (IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync)) ||
-                   (IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync));
         }
 
         #endregion

--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -548,6 +548,7 @@ namespace vMenuClient
         /// <param name="callbackObj">Optional callback for list changes</param>
         private void AddList(string menuId, string listId, string listLabel, object options, int defaultIndex, string description, object callbackObj = null)
         {
+            // Validate parameters
             if (!ValidateParameter(listId, "listId", "AddList")) return;
             if (HasIdConflict(listId, "AddList")) return;
 
@@ -557,48 +558,32 @@ namespace vMenuClient
             if (HasItemConflict(menu, listId, "AddList")) return;
 
             // Apply defaults for optional parameters
-            if (string.IsNullOrEmpty(listLabel))
-                listLabel = "List";
-            if (string.IsNullOrEmpty(description))
-                description = "";
+            listLabel = string.IsNullOrEmpty(listLabel) ? "List" : listLabel;
+            description = string.IsNullOrEmpty(description) ? "" : description;
 
-            List<string> optionsList;
+            // Parse options based on input type
+            List<string> optionsList = options switch
+            {
+                string jsonString => ParseJsonOptions(jsonString, listId),
+                object[] objectArray => objectArray.Select(o => o?.ToString() ?? "").ToList(),
+                List<object> objectList => objectList.Select(o => o?.ToString() ?? "").ToList(),
+                _ => null
+            };
 
-            // Handle different option input types
-            if (options is string jsonString)
+            if (optionsList == null)
             {
-                // Legacy support for JSON string
-                optionsList = JsonConvert.DeserializeObject<List<string>>(jsonString);
-            }
-            else if (options is object[] objectArray)
-            {
-                // Convert object array to string list
-                optionsList = objectArray.Select(o => o?.ToString() ?? "").ToList();
-            }
-            else if (options is List<object> objectList)
-            {
-                // Convert object list to string list
-                optionsList = objectList.Select(o => o?.ToString() ?? "").ToList();
-            }
-            else if (options == null)
-            {
-                // Provide default empty list if options is null
-                optionsList = new List<string> { "Option 1", "Option 2" };
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] No options provided for list {listId}, using default options.");
-            }
-            else
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Invalid options type for list {listId}. Expected array or JSON string.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] No valid options provided for list {listId}. List item will not be added.");
                 return;
             }
 
-            // Validate defaultIndex
+            // Validate and normalize defaultIndex
             if (defaultIndex < 0 || defaultIndex >= optionsList.Count)
             {
                 CitizenFX.Core.Debug.WriteLine($"[vMenu] Invalid defaultIndex {defaultIndex} for list {listId}. Using 0 instead.");
                 defaultIndex = 0;
             }
 
+            // Create and add the list item
             var menuListItem = new MenuListItem(listLabel, optionsList, defaultIndex, description)
             {
                 ItemData = listId
@@ -607,6 +592,22 @@ namespace vMenuClient
             AttachListCallbacks(menu, menuListItem, optionsList, callbackObj, listId);
             menu.AddMenuItem(menuListItem);
             menu.RefreshIndex();
+        }
+
+        /// <summary>
+        /// Parses JSON string options into a list
+        /// </summary>
+        private List<string> ParseJsonOptions(string jsonString, string listId)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<List<string>>(jsonString);
+            }
+            catch (JsonException ex)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Failed to parse JSON options for list {listId}: {ex.Message}");
+                return null;
+            }
         }
 
         /// <summary>
@@ -1129,27 +1130,39 @@ namespace vMenuClient
             // Common permission patterns based on menu titles/IDs
             return menuId switch
             {
+                // Direct menu mappings
                 "player-options" => IsAllowed(Permission.POMenu),
                 "online-players" => IsAllowed(Permission.OPMenu),
-                var id when id.Contains("banned-players") => IsAllowed(Permission.OPUnban) || IsAllowed(Permission.OPViewBannedPlayers),
                 "personal-vehicle-options" => IsAllowed(Permission.PVMenu),
                 "vehicle-options" => IsAllowed(Permission.VOMenu),
                 "vehicle-spawner" => IsAllowed(Permission.VSMenu),
+                "weapon-options" => IsAllowed(Permission.WPMenu),
+                "voice-chat-settings" => IsAllowed(Permission.VCMenu),
+                "player-appearance" or "character-appearance-options" or "mp-ped-customization" => IsAllowed(Permission.PAMenu),
+
+                // Pattern-based menu checks
+                var id when id.Contains("banned-players") => IsAllowed(Permission.OPUnban) || IsAllowed(Permission.OPViewBannedPlayers),
                 var id when id.Contains("saved") && id.Contains("vehicle") => IsAllowed(Permission.SVMenu),
-                "player-appearance" or "character-appearance-options" => IsAllowed(Permission.PAMenu),
-                "mp-ped-customization" => IsAllowed(Permission.PAMenu),
+                var id when id.Contains("weapon-loadouts") => IsAllowed(Permission.WLMenu),
                 var id when id.Contains("time") => IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync),
                 var id when id.Contains("weather") => IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync),
-                var id when id == "world" || id.Contains("world") => (IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync)) ||
-                                                                     (IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync)),
-                "weapon-options" => IsAllowed(Permission.WPMenu),
-                var id when id.Contains("weapon-loadouts") => IsAllowed(Permission.WLMenu),
-                "voice-chat-settings" => IsAllowed(Permission.VCMenu),
-                // Allow access to menus without specific restrictions
+                var id when id == "world" || id.Contains("world") => IsWorldMenuPermitted(),
+
+                // Unrestricted menus
                 var id when id.Contains("recording-options") || id.Contains("misc-settings") || id.Contains("about-vmenu") => true,
+
                 // Default to allowing access for unrecognized menus
                 _ => true
             };
+        }
+
+        /// <summary>
+        /// Checks if the world menu is permitted (requires time or weather permissions)
+        /// </summary>
+        private bool IsWorldMenuPermitted()
+        {
+            return (IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync)) ||
+                   (IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync));
         }
 
         #endregion

--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -58,17 +58,31 @@ namespace vMenuClient
         /// <returns>True if it matches a built-in menu ID</returns>
         private bool IsBuiltInMenuId(string id)
         {
-            return id.ToLower() switch
+            if (string.IsNullOrEmpty(id))
             {
-                "main" or "player" or "vehicle" or "world" or
-                "playeroptions" or "onlineplayers" or "bannedplayers" or
-                "personalvehicle" or "vehicleoptions" or "vehiclespawner" or
-                "savedvehicles" or "playerappearance" or "mppedcustomization" or
-                "timeoptions" or "weatheroptions" or "weaponoptions" or
-                "weaponloadouts" or "recording" or "miscsettings" or
-                "voicechat" or "about" => true,
-                _ => false
-            };
+                return false;
+            }
+
+            var normalizedId = id.ToLower().Replace(" ", "-");
+
+            // Get all built-in menu IDs based on their subtitles (same logic as GetAllMenuIds)
+            var uniqueMenus = MenuController.Menus.GroupBy(m => m.MenuSubtitle ?? m.MenuTitle).Select(g => g.First()).ToList();
+            foreach (var menu in uniqueMenus)
+            {
+                // Skip dynamic menus
+                if (DynamicMenus.ContainsValue(menu)) continue;
+
+                // Check if menu identifier matches
+                var menuIdentifier = menu.MenuSubtitle ?? menu.MenuTitle ?? "";
+                var normalizedTitle = menuIdentifier.ToLower().Replace(" ", "-");
+
+                if (normalizedTitle == normalizedId)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -113,7 +127,7 @@ namespace vMenuClient
             Exports.Add("DeleteMenu", new Action<string>(DeleteMenu));
 
             // Add Menu Items
-            Exports.Add("AddButton", new Action<string, string, string, string, object>(AddButton));
+            Exports.Add("AddButton", new Action<string, string, string, string, object, object>(AddButton));
             Exports.Add("AddList", new Action<string, string, string, object, int, string, object>(AddList));
             Exports.Add("AddCheckbox", new Action<string, string, string, string, bool, object>(AddCheckbox));
             Exports.Add("AddSlider", new Action<string, string, string, string, int, object>(AddSlider));
@@ -121,7 +135,7 @@ namespace vMenuClient
             Exports.Add("AddSubmenuButton", new Action<string, string, string, string, string, object>(AddSubmenuButton));
 
             // Modify Menu Items
-            Exports.Add("RemoveItem", new Action<string, string>(RemoveItem));
+            Exports.Add("RemoveItem", new Action<string, object>(RemoveItem));
 
             // Notifications
             Exports.Add("Notify", new Action<string, string>(notifExp));
@@ -161,7 +175,9 @@ namespace vMenuClient
             if (string.IsNullOrEmpty(menuDescription))
                 menuDescription = "";
 
-            var newMenu = new Menu(Game.Player.Name, menuTitle)
+            // Cache player name at creation time to prevent dynamic changes
+            var playerName = Game.Player.Name;
+            var newMenu = new Menu(playerName, menuTitle)
             {
                 MenuSubtitle = menuDescription
             };
@@ -175,7 +191,22 @@ namespace vMenuClient
                 {
                     newMenu.OnMenuOpen += (sender) =>
                     {
-                        callback.Invoke();
+                        try
+                        {
+                            BaseScript.TriggerEvent("vMenu:DelayedCallback", new Action(() => callback.Invoke()));
+                        }
+                        catch (System.IO.EndOfStreamException)
+                        {
+                            // Silently ignore - callback was deleted/garbage collected
+                        }
+                        catch (Exception ex)
+                        {
+                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking menu open callback for {menuId}: {ex.Message}");
+                            if (ex.InnerException != null)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Inner exception: {ex.InnerException.Message}");
+                            }
+                        }
                     };
                 }
                 else
@@ -185,12 +216,27 @@ namespace vMenuClient
                     {
                         try
                         {
+                            // Validate callback before invoking
+                            if (callbackObj == null)
+                            {
+                                return;
+                            }
+
                             dynamic dynamicCallback = callbackObj;
                             dynamicCallback();
                         }
+                        catch (System.IO.EndOfStreamException)
+                        {
+                            // Silently ignore - callback was deleted/garbage collected
+                        }
                         catch (Exception ex)
                         {
-                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking menu open callback for {menuId}: {ex.Message}");
+                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking menu open callback for {menuId}: {ex.GetType().Name} - {ex.Message}");
+                            if (ex.InnerException != null)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Inner exception: {ex.InnerException.GetType().Name} - {ex.InnerException.Message}");
+                            }
+                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Stack trace: {ex.StackTrace}");
                         }
                     };
                 }
@@ -243,23 +289,43 @@ namespace vMenuClient
 
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] OpenMenu: Menu with ID '{menuId}' not found. Available menus: {string.Join(", ", GetAllMenuIds())}");
                 return;
             }
 
+            // Close all currently open menus before opening the new one
+            MenuController.CloseAllMenus();
+
+            // Open the requested menu
             menu.OpenMenu();
         }
 
         /// <summary>
-        /// Adds a button to a menu
+        /// Adds a button item to a menu
         /// </summary>
         /// <param name="menuId">Target menu ID</param>
         /// <param name="buttonId">Unique button identifier</param>
-        /// <param name="buttonLabel">Button display text</param>
+        /// <param name="buttonLabel">Button label</param>
         /// <param name="buttonDescription">Button description</param>
-        /// <param name="callbackObj">Optional callback for button selection</param>
-        private void AddButton(string menuId, string buttonId, string buttonLabel, string buttonDescription, object callbackObj = null)
+        /// <param name="param5">Either rightLabel (string) or callback (object)</param>
+        /// <param name="param6">Optional callback if param5 is a string</param>
+        private void AddButton(string menuId, string buttonId, string buttonLabel, string buttonDescription, object param5 = null, object param6 = null)
         {
+            // Handle backwards compatibility: param5 can be either rightLabel (string) or callback (object)
+            string rightLabel = null;
+            object callbackObj = null;
+
+            if (param5 is string label)
+            {
+                // New signature: AddButton(menuId, buttonId, label, desc, rightLabel, callback)
+                rightLabel = label;
+                callbackObj = param6;
+            }
+            else
+            {
+                // Old signature: AddButton(menuId, buttonId, label, desc, callback)
+                callbackObj = param5;
+            }
             // Validate required parameters
             if (string.IsNullOrEmpty(buttonId))
             {
@@ -299,7 +365,8 @@ namespace vMenuClient
 
             var menuItem = new MenuItem(buttonLabel, buttonDescription)
             {
-                ItemData = buttonId
+                ItemData = buttonId,
+                Label = rightLabel ?? ""
             };
 
             if (callbackObj != null)
@@ -307,23 +374,29 @@ namespace vMenuClient
                 // Handle both C# delegates and Lua functions
                 if (callbackObj is CallbackDelegate callback)
                 {
-                    menu.OnItemSelect += (sender, item, index) =>
+                    menu.OnItemSelect += async (sender, item, index) =>
                     {
                         if (item == menuItem)
                         {
+                            await BaseScript.Delay(0);
                             callback.Invoke();
                         }
                     };
                 }
                 else if (callbackObj is Func<object> luaCallback)
                 {
-                    menu.OnItemSelect += (sender, item, index) =>
+                    menu.OnItemSelect += async (sender, item, index) =>
                     {
                         if (item == menuItem)
                         {
+                            await BaseScript.Delay(0);
                             try
                             {
                                 luaCallback.Invoke();
+                            }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
                             }
                             catch (Exception ex)
                             {
@@ -335,14 +408,19 @@ namespace vMenuClient
                 else
                 {
                     // Try to invoke as dynamic for other callback types
-                    menu.OnItemSelect += (sender, item, index) =>
+                    menu.OnItemSelect += async (sender, item, index) =>
                     {
                         if (item == menuItem)
                         {
+                            await BaseScript.Delay(0);
                             try
                             {
                                 dynamic dynamicCallback = callbackObj;
                                 dynamicCallback();
+                            }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
                             }
                             catch (Exception ex)
                             {
@@ -488,6 +566,10 @@ namespace vMenuClient
                                 dynamic dynamicCallback = callbackObj;
                                 dynamicCallback(false, currentValue, newIndex, oldIndex);
                             }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
+                            }
                             catch (Exception ex)
                             {
                                 CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for list {listId}: {ex.Message}");
@@ -504,6 +586,10 @@ namespace vMenuClient
                                 var selectedValue = optionsList[listIndex];
                                 dynamic dynamicCallback = callbackObj;
                                 dynamicCallback(true, selectedValue, listIndex, listIndex);
+                            }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
                             }
                             catch (Exception ex)
                             {
@@ -600,6 +686,10 @@ namespace vMenuClient
                                 dynamic dynamicCallback = luaCallback;
                                 dynamicCallback(_checked);
                             }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
+                            }
                             catch (Exception ex)
                             {
                                 CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for checkbox {checkboxId}: {ex.Message}");
@@ -618,6 +708,10 @@ namespace vMenuClient
                             {
                                 dynamic dynamicCallback = callbackObj;
                                 dynamicCallback(_checked);
+                            }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
                             }
                             catch (Exception ex)
                             {
@@ -722,6 +816,10 @@ namespace vMenuClient
                             {
                                 dynamic dynamicCallback = callbackObj;
                                 dynamicCallback(oldPosition, newPosition);
+                            }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
                             }
                             catch (Exception ex)
                             {
@@ -956,23 +1054,29 @@ namespace vMenuClient
                 // Handle both C# delegates and Lua functions
                 if (callbackObj is CallbackDelegate callback)
                 {
-                    parentMenu.OnItemSelect += (sender, item, index) =>
+                    parentMenu.OnItemSelect += async (sender, item, index) =>
                     {
                         if (item == submenuButton)
                         {
+                            await BaseScript.Delay(0);
                             callback.Invoke();
                         }
                     };
                 }
                 else if (callbackObj is Func<object> luaCallback)
                 {
-                    parentMenu.OnItemSelect += (sender, item, index) =>
+                    parentMenu.OnItemSelect += async (sender, item, index) =>
                     {
                         if (item == submenuButton)
                         {
+                            await BaseScript.Delay(0);
                             try
                             {
                                 luaCallback.Invoke();
+                            }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
                             }
                             catch (Exception ex)
                             {
@@ -984,14 +1088,19 @@ namespace vMenuClient
                 else
                 {
                     // Try to invoke as dynamic for other callback types
-                    parentMenu.OnItemSelect += (sender, item, index) =>
+                    parentMenu.OnItemSelect += async (sender, item, index) =>
                     {
                         if (item == submenuButton)
                         {
+                            await BaseScript.Delay(0);
                             try
                             {
                                 dynamic dynamicCallback = callbackObj;
                                 dynamicCallback();
+                            }
+                            catch (System.IO.EndOfStreamException)
+                            {
+                                // Silently ignore - callback was deleted/garbage collected
                             }
                             catch (Exception ex)
                             {
@@ -1006,11 +1115,11 @@ namespace vMenuClient
         }
 
         /// <summary>
-        /// Removes an item from a menu
+        /// Removes an item from a menu by ID (string) or index (int)
         /// </summary>
         /// <param name="menuId">Target menu ID</param>
-        /// <param name="itemId">Item identifier to remove</param>
-        private void RemoveItem(string menuId, string itemId)
+        /// <param name="itemIdOrIndex">Item identifier (string) or index (int) to remove</param>
+        private void RemoveItem(string menuId, object itemIdOrIndex)
         {
             // Validate required parameters
             if (string.IsNullOrEmpty(menuId))
@@ -1018,9 +1127,9 @@ namespace vMenuClient
                 CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: menuId cannot be null or empty.");
                 return;
             }
-            if (string.IsNullOrEmpty(itemId))
+            if (itemIdOrIndex == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: itemId cannot be null or empty.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: itemIdOrIndex cannot be null.");
                 return;
             }
 
@@ -1036,16 +1145,42 @@ namespace vMenuClient
                 return;
             }
 
-            // Find the item to remove, regardless of its type
-            var itemToRemove = menu.GetMenuItems().Find(item => item.ItemData as string == itemId);
+            var items = menu.GetMenuItems();
 
-            if (itemToRemove != null)
+            // Check if it's an int (index-based removal)
+            if (itemIdOrIndex is int index)
             {
-                menu.RemoveMenuItem(itemToRemove);
+                if (index < 0 || index >= items.Count)
+                {
+                    // Silent fail for out of range index (used for clearing menus in loops)
+                    return;
+                }
+                menu.RemoveMenuItem(items[index]);
+            }
+            // Otherwise treat as string (ID-based removal)
+            else if (itemIdOrIndex is string itemId)
+            {
+                if (string.IsNullOrEmpty(itemId))
+                {
+                    CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: itemId cannot be empty.");
+                    return;
+                }
+
+                // Find the item to remove by ItemData
+                var itemToRemove = items.Find(item => item.ItemData as string == itemId);
+
+                if (itemToRemove != null)
+                {
+                    menu.RemoveMenuItem(itemToRemove);
+                }
+                else
+                {
+                    CitizenFX.Core.Debug.WriteLine($"[vMenu] Item with ID {itemId} not found in menu {menuId}.");
+                }
             }
             else
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Item with ID {itemId} not found in menu {menuId}.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: itemIdOrIndex must be a string or int.");
             }
         }
 
@@ -1063,14 +1198,20 @@ namespace vMenuClient
             }
 
             Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
+
+            // First check dynamic menus
+            if (DynamicMenus.TryGetValue(menuId, out menu))
             {
-                menu = GetMenu(menuId);
+                menu.ClearMenuItems();
+                return;
             }
+
+            // Then check built-in menus using GetMenu
+            menu = GetMenu(menuId);
 
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] ClearMenu: Menu with ID '{menuId}' not found. Available menus: {string.Join(", ", GetAllMenuIds())}");
                 return;
             }
 
@@ -1154,16 +1295,27 @@ namespace vMenuClient
         /// <returns>Menu instance if found and permitted, null otherwise</returns>
         private Menu GetMenu(string menuId)
         {
-            // Search all registered menus (built-in and dynamic) - find first matching unique menu
+            // First check dynamic menus by exact ID
+            if (DynamicMenus.TryGetValue(menuId, out Menu dynamicMenu))
+            {
+                return dynamicMenu;
+            }
+
+            // Search built-in menus by normalized subtitle
             var uniqueMenus = MenuController.Menus.GroupBy(m => m.MenuSubtitle ?? m.MenuTitle).Select(g => g.First()).ToList();
+            var normalizedId = menuId.ToLower().Replace(" ", "-");
+
             foreach (var menu in uniqueMenus)
             {
+                // Skip dynamic menus (already checked above)
+                if (DynamicMenus.ContainsValue(menu)) continue;
+
                 // Try to match by menu subtitle (or title if subtitle is null)
                 var menuIdentifier = menu.MenuSubtitle ?? menu.MenuTitle ?? "";
                 var normalizedTitle = menuIdentifier.ToLower().Replace(" ", "-");
-                var normalizedId = menuId.ToLower().Replace(" ", "-");
 
-                if (normalizedTitle.Contains(normalizedId) || normalizedId.Contains(normalizedTitle))
+                // Exact match only
+                if (normalizedTitle == normalizedId)
                 {
                     // Basic permission check for known menu patterns
                     if (IsMenuPermitted(menu, menuId.ToLower()))

--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -26,6 +26,8 @@ namespace vMenuClient
         /// </summary>
         private static Dictionary<string, Menu> DynamicMenus = new Dictionary<string, Menu>();
 
+        #region Helper Methods
+
         /// <summary>
         /// Checks if an ID conflicts with any existing menu or item
         /// </summary>
@@ -102,7 +104,227 @@ namespace vMenuClient
             return false;
         }
 
+        /// <summary>
+        /// Validates a string parameter is not null or empty
+        /// </summary>
+        /// <param name="value">Value to check</param>
+        /// <param name="paramName">Parameter name for error message</param>
+        /// <param name="context">Context for error messages</param>
+        /// <returns>True if valid, false otherwise</returns>
+        private bool ValidateParameter(string value, string paramName, string context)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] {context}: {paramName} cannot be null or empty.");
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Retrieves a menu by ID from dynamic or built-in menus
+        /// </summary>
+        /// <param name="menuId">Menu identifier</param>
+        /// <returns>Menu instance if found, null otherwise</returns>
+        private Menu RetrieveMenu(string menuId)
+        {
+            if (DynamicMenus.TryGetValue(menuId, out Menu menu))
+            {
+                return menu;
+            }
+            return GetMenu(menuId);
+        }
+
+        /// <summary>
+        /// Safely invokes a callback with exception handling
+        /// </summary>
+        /// <param name="callbackObj">Callback object to invoke</param>
+        /// <param name="itemId">Item identifier for error logging</param>
+        /// <param name="args">Arguments to pass to callback</param>
+        private void SafeInvokeCallback(object callbackObj, string itemId, params object[] args)
+        {
+            try
+            {
+                if (callbackObj == null) return;
+
+                if (callbackObj is CallbackDelegate callback)
+                {
+                    callback.Invoke(args);
+                }
+                else if (callbackObj is Func<object> luaCallback)
+                {
+                    luaCallback.Invoke();
+                }
+                else
+                {
+                    dynamic dynamicCallback = callbackObj;
+                    // Dynamic invocation handles variable arguments automatically
+                    switch (args?.Length ?? 0)
+                    {
+                        case 0:
+                            dynamicCallback();
+                            break;
+                        case 1:
+                            dynamicCallback(args[0]);
+                            break;
+                        case 2:
+                            dynamicCallback(args[0], args[1]);
+                            break;
+                        case 3:
+                            dynamicCallback(args[0], args[1], args[2]);
+                            break;
+                        case 4:
+                            dynamicCallback(args[0], args[1], args[2], args[3]);
+                            break;
+                        default:
+                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Callback for {itemId} has unsupported number of arguments: {args.Length}");
+                            break;
+                    }
+                }
+            }
+            catch (System.IO.EndOfStreamException)
+            {
+                // Silently ignore - callback was deleted/garbage collected
+            }
+            catch (Exception ex)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for {itemId}: {ex.GetType().Name} - {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Attaches a callback to a menu item selection event
+        /// </summary>
+        private void AttachItemSelectCallback(Menu menu, MenuItem item, object callbackObj, string itemId)
+        {
+            if (callbackObj == null) return;
+
+            if (callbackObj is CallbackDelegate callback)
+            {
+                menu.OnItemSelect += async (sender, menuItem, index) =>
+                {
+                    if (menuItem == item)
+                    {
+                        await BaseScript.Delay(0);
+                        SafeInvokeCallback(callback, itemId);
+                    }
+                };
+            }
+            else
+            {
+                menu.OnItemSelect += async (sender, menuItem, index) =>
+                {
+                    if (menuItem == item)
+                    {
+                        await BaseScript.Delay(0);
+                        SafeInvokeCallback(callbackObj, itemId);
+                    }
+                };
+            }
+        }
+
+        /// <summary>
+        /// Attaches a callback to a checkbox change event
+        /// </summary>
+        private void AttachCheckboxCallback(Menu menu, MenuCheckboxItem item, object callbackObj, string itemId)
+        {
+            if (callbackObj == null) return;
+
+            menu.OnCheckboxChange += (sender, menuItem, index, _checked) =>
+            {
+                if (menuItem == item)
+                {
+                    SafeInvokeCallback(callbackObj, itemId, _checked);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Attaches callbacks to a list item events
+        /// </summary>
+        private void AttachListCallbacks(Menu menu, MenuListItem item, List<string> options, object callbackObj, string itemId)
+        {
+            if (callbackObj == null) return;
+
+            // Listen for index changes (browsing through list)
+            menu.OnListIndexChange += (sender, menuItem, oldIndex, newIndex, itemIndex) =>
+            {
+                if (menuItem == item)
+                {
+                    var currentValue = options[newIndex];
+                    SafeInvokeCallback(callbackObj, itemId, false, currentValue, newIndex, oldIndex);
+                }
+            };
+
+            // Listen for item selection (pressing enter/select)
+            menu.OnListItemSelect += (sender, menuItem, listIndex, itemIndex) =>
+            {
+                if (menuItem == item)
+                {
+                    var selectedValue = options[listIndex];
+                    SafeInvokeCallback(callbackObj, itemId, true, selectedValue, listIndex, listIndex);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Attaches a callback to a slider position change event
+        /// </summary>
+        private void AttachSliderCallback(Menu menu, MenuSliderItem item, object callbackObj, string itemId)
+        {
+            if (callbackObj == null) return;
+
+            menu.OnSliderPositionChange += (sender, menuItem, oldPosition, newPosition, itemIndex) =>
+            {
+                if (menuItem == item)
+                {
+                    SafeInvokeCallback(callbackObj, itemId, oldPosition, newPosition);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Attaches a callback to a menu open event
+        /// </summary>
+        private void AttachMenuOpenCallback(Menu menu, object callbackObj, string menuId)
+        {
+            if (callbackObj == null) return;
+
+            if (callbackObj is CallbackDelegate callback)
+            {
+                menu.OnMenuOpen += (sender) =>
+                {
+                    try
+                    {
+                        BaseScript.TriggerEvent("vMenu:DelayedCallback", new Action(() => callback.Invoke()));
+                    }
+                    catch (System.IO.EndOfStreamException)
+                    {
+                        // Silently ignore - callback was deleted/garbage collected
+                    }
+                    catch (Exception ex)
+                    {
+                        CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking menu open callback for {menuId}: {ex.Message}");
+                        if (ex.InnerException != null)
+                        {
+                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Inner exception: {ex.InnerException.Message}");
+                        }
+                    }
+                };
+            }
+            else
+            {
+                menu.OnMenuOpen += (sender) =>
+                {
+                    SafeInvokeCallback(callbackObj, null, menuId);
+                };
+            }
+        }
+
+        #endregion
+
         #region Export Registration and Initialization
+
         /// <summary>
         /// Initialize dynamic menu exports for plugin usage
         /// </summary>
@@ -142,7 +364,10 @@ namespace vMenuClient
 
             // Menu Information
             Exports.Add("GetAllMenuIds", new Func<string[]>(GetAllMenuIds));
+            Exports.Add("GetMenu", new Func<string, object>(GetMenuExport));
+            Exports.Add("IsMenuPermitted", new Func<string, bool>(IsMenuPermittedExport));
         }
+
         #endregion
 
         #region Export Implementation Methods
@@ -156,18 +381,8 @@ namespace vMenuClient
         /// <param name="callbackObj">Optional callback for menu open events</param>
         private void CreateMenu(string menuId, string menuTitle, string menuDescription, object callbackObj)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] CreateMenu: menuId cannot be null or empty.");
-                return;
-            }
-
-            // Check for any ID conflicts
-            if (HasIdConflict(menuId, "CreateMenu"))
-            {
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "CreateMenu")) return;
+            if (HasIdConflict(menuId, "CreateMenu")) return;
 
             // Apply defaults for optional parameters
             if (string.IsNullOrEmpty(menuTitle))
@@ -184,63 +399,7 @@ namespace vMenuClient
             MenuController.AddMenu(newMenu);
             DynamicMenus[menuId] = newMenu;
 
-            if (callbackObj != null)
-            {
-                // Handle both C# delegates and Lua functions
-                if (callbackObj is CallbackDelegate callback)
-                {
-                    newMenu.OnMenuOpen += (sender) =>
-                    {
-                        try
-                        {
-                            BaseScript.TriggerEvent("vMenu:DelayedCallback", new Action(() => callback.Invoke()));
-                        }
-                        catch (System.IO.EndOfStreamException)
-                        {
-                            // Silently ignore - callback was deleted/garbage collected
-                        }
-                        catch (Exception ex)
-                        {
-                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking menu open callback for {menuId}: {ex.Message}");
-                            if (ex.InnerException != null)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Inner exception: {ex.InnerException.Message}");
-                            }
-                        }
-                    };
-                }
-                else
-                {
-                    // Handle Lua functions and dynamic callbacks
-                    newMenu.OnMenuOpen += (sender) =>
-                    {
-                        try
-                        {
-                            // Validate callback before invoking
-                            if (callbackObj == null)
-                            {
-                                return;
-                            }
-
-                            dynamic dynamicCallback = callbackObj;
-                            dynamicCallback();
-                        }
-                        catch (System.IO.EndOfStreamException)
-                        {
-                            // Silently ignore - callback was deleted/garbage collected
-                        }
-                        catch (Exception ex)
-                        {
-                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking menu open callback for {menuId}: {ex.GetType().Name} - {ex.Message}");
-                            if (ex.InnerException != null)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Inner exception: {ex.InnerException.GetType().Name} - {ex.InnerException.Message}");
-                            }
-                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Stack trace: {ex.StackTrace}");
-                        }
-                    };
-                }
-            }
+            AttachMenuOpenCallback(newMenu, callbackObj, menuId);
         }
 
         /// <summary>
@@ -250,21 +409,20 @@ namespace vMenuClient
         /// <param name="type">Notification type (error, info, success, or default)</param>
         private void notifExp(string message, string type)
         {
-            if (type == "error")
+            switch (type)
             {
-                Notify.Error(message);
-            }
-            else if (type == "info")
-            {
-                Notify.Info(message);
-            }
-            else if (type == "success")
-            {
-                Notify.Success(message);
-            }
-            else
-            {
-                Notify.Alert(message);
+                case "error":
+                    Notify.Error(message);
+                    break;
+                case "info":
+                    Notify.Info(message);
+                    break;
+                case "success":
+                    Notify.Success(message);
+                    break;
+                default:
+                    Notify.Alert(message);
+                    break;
             }
         }
 
@@ -274,18 +432,9 @@ namespace vMenuClient
         /// <param name="menuId">Menu identifier</param>
         private void OpenMenu(string menuId)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] OpenMenu: menuId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "OpenMenu")) return;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
+            Menu menu = RetrieveMenu(menuId);
 
             if (menu == null)
             {
@@ -326,36 +475,18 @@ namespace vMenuClient
                 // Old signature: AddButton(menuId, buttonId, label, desc, callback)
                 callbackObj = param5;
             }
-            // Validate required parameters
-            if (string.IsNullOrEmpty(buttonId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddButton: buttonId cannot be null or empty.");
-                return;
-            }
 
-            // Check for ID conflicts (menu names, other items)
-            if (HasIdConflict(buttonId, "AddButton"))
-            {
-                return;
-            }
+            if (!ValidateParameter(buttonId, "buttonId", "AddButton")) return;
+            if (HasIdConflict(buttonId, "AddButton")) return;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddButton: Menu with ID {menuId} not found.");
                 return;
             }
 
-            // Check for item conflicts within this menu
-            if (HasItemConflict(menu, buttonId, "AddButton"))
-            {
-                return;
-            }
+            if (HasItemConflict(menu, buttonId, "AddButton")) return;
 
             // Apply defaults for optional parameters
             if (string.IsNullOrEmpty(buttonLabel))
@@ -369,68 +500,7 @@ namespace vMenuClient
                 Label = rightLabel ?? ""
             };
 
-            if (callbackObj != null)
-            {
-                // Handle both C# delegates and Lua functions
-                if (callbackObj is CallbackDelegate callback)
-                {
-                    menu.OnItemSelect += async (sender, item, index) =>
-                    {
-                        if (item == menuItem)
-                        {
-                            await BaseScript.Delay(0);
-                            callback.Invoke();
-                        }
-                    };
-                }
-                else if (callbackObj is Func<object> luaCallback)
-                {
-                    menu.OnItemSelect += async (sender, item, index) =>
-                    {
-                        if (item == menuItem)
-                        {
-                            await BaseScript.Delay(0);
-                            try
-                            {
-                                luaCallback.Invoke();
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for button {buttonId}: {ex.Message}");
-                            }
-                        }
-                    };
-                }
-                else
-                {
-                    // Try to invoke as dynamic for other callback types
-                    menu.OnItemSelect += async (sender, item, index) =>
-                    {
-                        if (item == menuItem)
-                        {
-                            await BaseScript.Delay(0);
-                            try
-                            {
-                                dynamic dynamicCallback = callbackObj;
-                                dynamicCallback();
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking dynamic callback for button {buttonId}: {ex.Message}");
-                            }
-                        }
-                    };
-                }
-            }
-
+            AttachItemSelectCallback(menu, menuItem, callbackObj, buttonId);
             menu.AddMenuItem(menuItem);
             menu.RefreshIndex();
         }
@@ -447,36 +517,17 @@ namespace vMenuClient
         /// <param name="callbackObj">Optional callback for list changes</param>
         private void AddList(string menuId, string listId, string listLabel, object options, int defaultIndex, string description, object callbackObj = null)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(listId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddList: listId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(listId, "listId", "AddList")) return;
+            if (HasIdConflict(listId, "AddList")) return;
 
-            // Check for ID conflicts (menu names, other items)
-            if (HasIdConflict(listId, "AddList"))
-            {
-                return;
-            }
-
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddList: Menu with ID {menuId} not found.");
                 return;
             }
 
-            // Check for item conflicts within this menu
-            if (HasItemConflict(menu, listId, "AddList"))
-            {
-                return;
-            }
+            if (HasItemConflict(menu, listId, "AddList")) return;
 
             // Apply defaults for optional parameters
             if (string.IsNullOrEmpty(listLabel))
@@ -526,80 +577,7 @@ namespace vMenuClient
                 ItemData = listId
             };
 
-            if (callbackObj != null)
-            {
-                // Handle both C# delegates and Lua functions
-                if (callbackObj is CallbackDelegate callback)
-                {
-                    // Listen for index changes (browsing through list)
-                    menu.OnListIndexChange += (sender, item, oldIndex, newIndex, itemIndex) =>
-                    {
-                        if (item == menuListItem)
-                        {
-                            var currentValue = optionsList[newIndex];
-                            var oldValue = optionsList[oldIndex];
-                            callback.Invoke(false, currentValue, newIndex, oldIndex);
-                        }
-                    };
-
-                    // Listen for item selection (pressing enter/select)
-                    menu.OnListItemSelect += (sender, item, listIndex, itemIndex) =>
-                    {
-                        if (item == menuListItem)
-                        {
-                            var selectedValue = optionsList[listIndex];
-                            callback.Invoke(true, selectedValue, listIndex, listIndex);
-                        }
-                    };
-                }
-                else
-                {
-                    // Handle Lua functions and dynamic callbacks
-                    menu.OnListIndexChange += (sender, item, oldIndex, newIndex, itemIndex) =>
-                    {
-                        if (item == menuListItem)
-                        {
-                            try
-                            {
-                                var currentValue = optionsList[newIndex];
-                                var oldValue = optionsList[oldIndex];
-                                dynamic dynamicCallback = callbackObj;
-                                dynamicCallback(false, currentValue, newIndex, oldIndex);
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for list {listId}: {ex.Message}");
-                            }
-                        }
-                    };
-
-                    menu.OnListItemSelect += (sender, item, listIndex, itemIndex) =>
-                    {
-                        if (item == menuListItem)
-                        {
-                            try
-                            {
-                                var selectedValue = optionsList[listIndex];
-                                dynamic dynamicCallback = callbackObj;
-                                dynamicCallback(true, selectedValue, listIndex, listIndex);
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for list {listId}: {ex.Message}");
-                            }
-                        }
-                    };
-                }
-            }
-
+            AttachListCallbacks(menu, menuListItem, optionsList, callbackObj, listId);
             menu.AddMenuItem(menuListItem);
             menu.RefreshIndex();
         }
@@ -615,41 +593,18 @@ namespace vMenuClient
         /// <param name="callbackObj">Optional callback for checkbox changes</param>
         private void AddCheckbox(string menuId, string checkboxId, string checkboxLabel, string description, bool defaultValue, object callbackObj = null)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddCheckbox: menuId cannot be null or empty.");
-                return;
-            }
-            if (string.IsNullOrEmpty(checkboxId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddCheckbox: checkboxId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "AddCheckbox")) return;
+            if (!ValidateParameter(checkboxId, "checkboxId", "AddCheckbox")) return;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddCheckbox: Menu with ID {menuId} not found.");
                 return;
             }
 
-            // Check for ID conflicts (menu names, other items)
-            if (HasIdConflict(checkboxId, "AddCheckbox"))
-            {
-                return;
-            }
-
-            // Check for item conflicts within this menu
-            if (HasItemConflict(menu, checkboxId, "AddCheckbox"))
-            {
-                return;
-            }
+            if (HasIdConflict(checkboxId, "AddCheckbox")) return;
+            if (HasItemConflict(menu, checkboxId, "AddCheckbox")) return;
 
             // Apply defaults for optional parameters
             if (string.IsNullOrEmpty(checkboxLabel))
@@ -662,66 +617,7 @@ namespace vMenuClient
                 ItemData = checkboxId
             };
 
-            if (callbackObj != null)
-            {
-                // Handle both C# delegates and Lua functions
-                if (callbackObj is CallbackDelegate callback)
-                {
-                    menu.OnCheckboxChange += (sender, item, index, _checked) =>
-                    {
-                        if (item == menuCheckboxItem)
-                        {
-                            callback.Invoke(_checked);
-                        }
-                    };
-                }
-                else if (callbackObj is Func<object> luaCallback)
-                {
-                    menu.OnCheckboxChange += (sender, item, index, _checked) =>
-                    {
-                        if (item == menuCheckboxItem)
-                        {
-                            try
-                            {
-                                dynamic dynamicCallback = luaCallback;
-                                dynamicCallback(_checked);
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for checkbox {checkboxId}: {ex.Message}");
-                            }
-                        }
-                    };
-                }
-                else
-                {
-                    // Try to invoke as dynamic for other callback types
-                    menu.OnCheckboxChange += (sender, item, index, _checked) =>
-                    {
-                        if (item == menuCheckboxItem)
-                        {
-                            try
-                            {
-                                dynamic dynamicCallback = callbackObj;
-                                dynamicCallback(_checked);
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking dynamic callback for checkbox {checkboxId}: {ex.Message}");
-                            }
-                        }
-                    };
-                }
-            }
-
+            AttachCheckboxCallback(menu, menuCheckboxItem, callbackObj, checkboxId);
             menu.AddMenuItem(menuCheckboxItem);
             menu.RefreshIndex();
         }
@@ -737,41 +633,18 @@ namespace vMenuClient
         /// <param name="callbackObj">Optional callback for slider changes</param>
         private void AddSlider(string menuId, string sliderId, string sliderLabel, string description, int defaultValue, object callbackObj = null)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSlider: menuId cannot be null or empty.");
-                return;
-            }
-            if (string.IsNullOrEmpty(sliderId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSlider: sliderId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "AddSlider")) return;
+            if (!ValidateParameter(sliderId, "sliderId", "AddSlider")) return;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSlider: Menu with ID {menuId} not found.");
                 return;
             }
 
-            // Check for ID conflicts (menu names, other items)
-            if (HasIdConflict(sliderId, "AddSlider"))
-            {
-                return;
-            }
-
-            // Check for item conflicts within this menu
-            if (HasItemConflict(menu, sliderId, "AddSlider"))
-            {
-                return;
-            }
+            if (HasIdConflict(sliderId, "AddSlider")) return;
+            if (HasItemConflict(menu, sliderId, "AddSlider")) return;
 
             // Apply defaults for optional parameters
             if (string.IsNullOrEmpty(sliderLabel))
@@ -791,45 +664,7 @@ namespace vMenuClient
                 ItemData = sliderId
             };
 
-            if (callbackObj != null)
-            {
-                // Handle both C# delegates and Lua functions
-                if (callbackObj is CallbackDelegate callback)
-                {
-                    // Listen for position changes
-                    menu.OnSliderPositionChange += (sender, item, oldPosition, newPosition, itemIndex) =>
-                    {
-                        if (item == menuSliderItem)
-                        {
-                            callback.Invoke(oldPosition, newPosition);
-                        }
-                    };
-                }
-                else
-                {
-                    // Handle Lua functions and dynamic callbacks
-                    menu.OnSliderPositionChange += (sender, item, oldPosition, newPosition, itemIndex) =>
-                    {
-                        if (item == menuSliderItem)
-                        {
-                            try
-                            {
-                                dynamic dynamicCallback = callbackObj;
-                                dynamicCallback(oldPosition, newPosition);
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for slider {sliderId}: {ex.Message}");
-                            }
-                        }
-                    };
-                }
-            }
-
+            AttachSliderCallback(menu, menuSliderItem, callbackObj, sliderId);
             menu.AddMenuItem(menuSliderItem);
             menu.RefreshIndex();
         }
@@ -843,41 +678,18 @@ namespace vMenuClient
         /// <param name="description">Optional spacer description</param>
         private void AddSpacer(string menuId, string spacerId, string spacerText, string description)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSpacer: menuId cannot be null or empty.");
-                return;
-            }
-            if (string.IsNullOrEmpty(spacerId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSpacer: spacerId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "AddSpacer")) return;
+            if (!ValidateParameter(spacerId, "spacerId", "AddSpacer")) return;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSpacer: Menu with ID {menuId} not found.");
                 return;
             }
 
-            // Check for ID conflicts (menu names, other items)
-            if (HasIdConflict(spacerId, "AddSpacer"))
-            {
-                return;
-            }
-
-            // Check for item conflicts within this menu
-            if (HasItemConflict(menu, spacerId, "AddSpacer"))
-            {
-                return;
-            }
+            if (HasIdConflict(spacerId, "AddSpacer")) return;
+            if (HasItemConflict(menu, spacerId, "AddSpacer")) return;
 
             // Apply defaults for optional parameters
             if (string.IsNullOrEmpty(spacerText))
@@ -896,22 +708,12 @@ namespace vMenuClient
         /// <param name="menuId">Target menu ID</param>
         private void RefreshMenu(string menuId)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] RefreshMenu: menuId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "RefreshMenu")) return;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] RefreshMenu: Menu with ID {menuId} not found.");
                 return;
             }
 
@@ -932,22 +734,12 @@ namespace vMenuClient
         /// <param name="menuId">Menu ID to close</param>
         private void CloseMenu(string menuId)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] CloseMenu: menuId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "CloseMenu")) return;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] CloseMenu: Menu with ID {menuId} not found.");
                 return;
             }
 
@@ -968,31 +760,11 @@ namespace vMenuClient
         /// <param name="callbackObj">Optional callback for button selection</param>
         private void AddSubmenuButton(string parentMenuId, string buttonId, string submenuId, string buttonLabel, string buttonDescription, object callbackObj = null)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(parentMenuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: parentMenuId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(parentMenuId, "parentMenuId", "AddSubmenuButton")) return;
+            if (!ValidateParameter(buttonId, "buttonId", "AddSubmenuButton")) return;
+            if (!ValidateParameter(submenuId, "submenuId", "AddSubmenuButton")) return;
 
-
-
-            if (string.IsNullOrEmpty(buttonId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: buttonId cannot be null or empty.");
-                return;
-            }
-            if (string.IsNullOrEmpty(submenuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: submenuId cannot be null or empty.");
-                return;
-            }
-
-            // Check for ID conflicts for buttonId
-            if (HasIdConflict(buttonId, "AddSubmenuButton"))
-            {
-                return;
-            }
+            if (HasIdConflict(buttonId, "AddSubmenuButton")) return;
 
             // Verify submenu exists (either dynamic or built-in)
             if (!DynamicMenus.ContainsKey(submenuId) && GetMenu(submenuId) == null)
@@ -1001,36 +773,22 @@ namespace vMenuClient
                 return;
             }
 
-
-            Menu parentMenu = null;
-            if (!DynamicMenus.TryGetValue(parentMenuId, out parentMenu))
-            {
-                parentMenu = GetMenu(parentMenuId);
-            }
-
-            Menu submenu = null;
-            if (!DynamicMenus.TryGetValue(submenuId, out submenu))
-            {
-                submenu = GetMenu(submenuId);
-            }
+            Menu parentMenu = RetrieveMenu(parentMenuId);
+            Menu submenu = RetrieveMenu(submenuId);
 
             if (parentMenu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Parent menu {parentMenuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: Parent menu {parentMenuId} not found.");
                 return;
             }
 
             if (submenu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Submenu {submenuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: Submenu {submenuId} not found.");
                 return;
             }
 
-            // Check for item conflicts within parent menu
-            if (HasItemConflict(parentMenu, buttonId, "AddSubmenuButton"))
-            {
-                return;
-            }
+            if (HasItemConflict(parentMenu, buttonId, "AddSubmenuButton")) return;
 
             // Apply defaults for optional parameters
             if (string.IsNullOrEmpty(buttonLabel))
@@ -1049,68 +807,7 @@ namespace vMenuClient
             MenuController.BindMenuItem(parentMenu, submenu, submenuButton);
             submenu.RefreshIndex();
 
-            if (callbackObj != null)
-            {
-                // Handle both C# delegates and Lua functions
-                if (callbackObj is CallbackDelegate callback)
-                {
-                    parentMenu.OnItemSelect += async (sender, item, index) =>
-                    {
-                        if (item == submenuButton)
-                        {
-                            await BaseScript.Delay(0);
-                            callback.Invoke();
-                        }
-                    };
-                }
-                else if (callbackObj is Func<object> luaCallback)
-                {
-                    parentMenu.OnItemSelect += async (sender, item, index) =>
-                    {
-                        if (item == submenuButton)
-                        {
-                            await BaseScript.Delay(0);
-                            try
-                            {
-                                luaCallback.Invoke();
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for submenu button {buttonLabel}: {ex.Message}");
-                            }
-                        }
-                    };
-                }
-                else
-                {
-                    // Try to invoke as dynamic for other callback types
-                    parentMenu.OnItemSelect += async (sender, item, index) =>
-                    {
-                        if (item == submenuButton)
-                        {
-                            await BaseScript.Delay(0);
-                            try
-                            {
-                                dynamic dynamicCallback = callbackObj;
-                                dynamicCallback();
-                            }
-                            catch (System.IO.EndOfStreamException)
-                            {
-                                // Silently ignore - callback was deleted/garbage collected
-                            }
-                            catch (Exception ex)
-                            {
-                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking dynamic callback for submenu button {buttonLabel}: {ex.Message}");
-                            }
-                        }
-                    };
-                }
-            }
-
+            AttachItemSelectCallback(parentMenu, submenuButton, callbackObj, buttonId);
             parentMenu.RefreshIndex();
         }
 
@@ -1121,27 +818,18 @@ namespace vMenuClient
         /// <param name="itemIdOrIndex">Item identifier (string) or index (int) to remove</param>
         private void RemoveItem(string menuId, object itemIdOrIndex)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: menuId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "RemoveItem")) return;
+
             if (itemIdOrIndex == null)
             {
                 CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: itemIdOrIndex cannot be null.");
                 return;
             }
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: Menu with ID {menuId} not found.");
                 return;
             }
 
@@ -1175,7 +863,7 @@ namespace vMenuClient
                 }
                 else
                 {
-                    CitizenFX.Core.Debug.WriteLine($"[vMenu] Item with ID {itemId} not found in menu {menuId}.");
+                    CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: Item with ID {itemId} not found in menu {menuId}.");
                 }
             }
             else
@@ -1190,25 +878,9 @@ namespace vMenuClient
         /// <param name="menuId">Target menu ID</param>
         private void ClearMenu(string menuId)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] ClearMenu: menuId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "ClearMenu")) return;
 
-            Menu menu = null;
-
-            // First check dynamic menus
-            if (DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu.ClearMenuItems();
-                return;
-            }
-
-            // Then check built-in menus using GetMenu
-            menu = GetMenu(menuId);
-
+            Menu menu = RetrieveMenu(menuId);
             if (menu == null)
             {
                 CitizenFX.Core.Debug.WriteLine($"[vMenu] ClearMenu: Menu with ID '{menuId}' not found. Available menus: {string.Join(", ", GetAllMenuIds())}");
@@ -1225,24 +897,10 @@ namespace vMenuClient
         /// <returns>True if menu exists, false otherwise</returns>
         private bool CheckMenu(string menuId)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] CheckMenu: menuId cannot be null or empty.");
-                return false;
-            }
+            if (!ValidateParameter(menuId, "menuId", "CheckMenu")) return false;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
-            {
-                menu = GetMenu(menuId);
-            }
-
-            if (menu == null)
-            {
-                return false;
-            }
-            return true;
+            Menu menu = RetrieveMenu(menuId);
+            return menu != null;
         }
 
         /// <summary>
@@ -1251,17 +909,11 @@ namespace vMenuClient
         /// <param name="menuId">Menu ID to delete</param>
         private void DeleteMenu(string menuId)
         {
-            // Validate required parameters
-            if (string.IsNullOrEmpty(menuId))
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] DeleteMenu: menuId cannot be null or empty.");
-                return;
-            }
+            if (!ValidateParameter(menuId, "menuId", "DeleteMenu")) return;
 
-            Menu menu = null;
-            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            if (!DynamicMenus.TryGetValue(menuId, out Menu menu))
             {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] DeleteMenu: Menu with ID {menuId} not found.");
                 return;
             }
 
@@ -1287,12 +939,11 @@ namespace vMenuClient
             menu = null;
         }
 
-
         /// <summary>
-        /// Dynamically finds built-in vMenu menus by ID with permission checking
+        /// Dynamically finds built-in vMenu menus by ID (without permission filtering)
         /// </summary>
         /// <param name="menuId">Menu identifier string</param>
-        /// <returns>Menu instance if found and permitted, null otherwise</returns>
+        /// <returns>Menu instance if found, null otherwise</returns>
         private Menu GetMenu(string menuId)
         {
             // First check dynamic menus by exact ID
@@ -1317,11 +968,7 @@ namespace vMenuClient
                 // Exact match only
                 if (normalizedTitle == normalizedId)
                 {
-                    // Basic permission check for known menu patterns
-                    if (IsMenuPermitted(menu, menuId.ToLower()))
-                    {
-                        return menu;
-                    }
+                    return menu;
                 }
             }
 
@@ -1329,9 +976,19 @@ namespace vMenuClient
         }
 
         /// <summary>
-        /// Export function to get all available menu IDs
+        /// Export wrapper for GetMenu that returns an object (for export compatibility)
         /// </summary>
-        /// <returns>Array of menu IDs that can be accessed through GetMenu</returns>
+        /// <param name="menuId">Menu identifier</param>
+        /// <returns>Menu instance as object if found, null otherwise</returns>
+        private object GetMenuExport(string menuId)
+        {
+            return GetMenu(menuId);
+        }
+
+        /// <summary>
+        /// Export function to get all available menu IDs (without permission filtering)
+        /// </summary>
+        /// <returns>Array of all menu IDs that exist</returns>
         private string[] GetAllMenuIds()
         {
             var menuIds = new List<string>();
@@ -1349,17 +1006,37 @@ namespace vMenuClient
                 // Skip dynamic menus (already added above)
                 if (DynamicMenus.ContainsValue(menu)) continue;
 
-                // Check if menu is permitted
                 var menuIdentifier = menu.MenuSubtitle ?? menu.MenuTitle ?? "";
                 var normalizedTitle = menuIdentifier.ToLower().Replace(" ", "-");
-                if (IsMenuPermitted(menu, normalizedTitle))
-                {
-                    menuIds.Add(normalizedTitle);
-                }
+                menuIds.Add(normalizedTitle);
             }
 
             // Remove duplicates and sort
             return menuIds.Distinct().OrderBy(id => id).ToArray();
+        }
+
+        /// <summary>
+        /// Export function to check if a menu is permitted based on vMenu permissions
+        /// </summary>
+        /// <param name="menuId">Menu identifier</param>
+        /// <returns>True if permitted, false otherwise</returns>
+        private bool IsMenuPermittedExport(string menuId)
+        {
+            if (string.IsNullOrEmpty(menuId))
+            {
+                return false;
+            }
+
+            var normalizedId = menuId.ToLower().Replace(" ", "-");
+
+            // Get the menu to check if it exists
+            var menu = GetMenu(normalizedId);
+            if (menu == null)
+            {
+                return false;
+            }
+
+            return IsMenuPermitted(menu, normalizedId);
         }
 
         /// <summary>

--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using CitizenFX.Core;
 using MenuAPI;
 using Newtonsoft.Json;
-using static vMenuClient.CommonFunctions;
 using static vMenuShared.PermissionsManager;
 using static vMenuShared.ConfigManager;
 

--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -1,0 +1,1222 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CitizenFX.Core;
+using MenuAPI;
+using Newtonsoft.Json;
+using static vMenuClient.CommonFunctions;
+using static vMenuShared.PermissionsManager;
+using static vMenuShared.ConfigManager;
+
+namespace vMenuClient
+{
+    /// <summary>
+    /// Handles all dynamic menu exports for plugin usage
+    /// </summary>
+    public partial class MainMenu
+    {
+        /// <summary>
+        /// Callback delegate for export functions
+        /// </summary>
+        /// <param name="args">Optional arguments passed to the callback</param>
+        private delegate void CallbackDelegate(params object[] args);
+
+        /// <summary>
+        /// Dictionary to store dynamically created menus
+        /// </summary>
+        private static Dictionary<string, Menu> DynamicMenus = new Dictionary<string, Menu>();
+
+        /// <summary>
+        /// Checks if an ID conflicts with any existing menu or item
+        /// </summary>
+        /// <param name="id">ID to check</param>
+        /// <param name="context">Context for error messages</param>
+        /// <returns>True if there's a conflict</returns>
+        private bool HasIdConflict(string id, string context)
+        {
+            // Check against dynamic menus
+            if (DynamicMenus.ContainsKey(id))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] {context}: ID '{id}' conflicts with existing dynamic menu.");
+                return true;
+            }
+
+            // Check against core built-in menus only (strict matching)
+            if (IsBuiltInMenuId(id))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] {context}: ID '{id}' conflicts with built-in vMenu menu.");
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if an ID matches a core built-in menu (strict matching only)
+        /// </summary>
+        /// <param name="id">ID to check</param>
+        /// <returns>True if it matches a built-in menu ID</returns>
+        private bool IsBuiltInMenuId(string id)
+        {
+            return id.ToLower() switch
+            {
+                "main" or "player" or "vehicle" or "world" or
+                "playeroptions" or "onlineplayers" or "bannedplayers" or
+                "personalvehicle" or "vehicleoptions" or "vehiclespawner" or
+                "savedvehicles" or "playerappearance" or "mppedcustomization" or
+                "timeoptions" or "weatheroptions" or "weaponoptions" or
+                "weaponloadouts" or "recording" or "miscsettings" or
+                "voicechat" or "about" => true,
+                _ => false
+            };
+        }
+
+        /// <summary>
+        /// Checks if an item ID conflicts within a specific menu
+        /// </summary>
+        /// <param name="menu">Menu to check</param>
+        /// <param name="itemId">Item ID to check</param>
+        /// <param name="context">Context for error messages</param>
+        /// <returns>True if there's a conflict</returns>
+        private bool HasItemConflict(Menu menu, string itemId, string context)
+        {
+            if (menu.GetMenuItems().Any(item => item.ItemData as string == itemId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] {context}: Item with ID '{itemId}' already exists in this menu.");
+                return true;
+            }
+            return false;
+        }
+
+        #region Export Registration and Initialization
+        /// <summary>
+        /// Initialize dynamic menu exports for plugin usage
+        /// </summary>
+        public void InitializeDynamicMenuExports()
+        {
+            RegisterDynamicMenuExports();
+        }
+
+        /// <summary>
+        /// Registers all dynamic menu exports
+        /// </summary>
+        private void RegisterDynamicMenuExports()
+        {
+            // Core Menu Management
+            Exports.Add("CreateMenu", new Action<string, string, string, object>(CreateMenu));
+            Exports.Add("OpenMenu", new Action<string>(OpenMenu));
+            Exports.Add("CloseMenu", new Action<string>(CloseMenu));
+            Exports.Add("CloseAllMenus", new Action(CloseAllMenus));
+            Exports.Add("CheckMenu", new Func<string, bool>(CheckMenu));
+            Exports.Add("ClearMenu", new Action<string>(ClearMenu));
+            Exports.Add("RefreshMenu", new Action<string>(RefreshMenu));
+            Exports.Add("DeleteMenu", new Action<string>(DeleteMenu));
+
+            // Add Menu Items
+            Exports.Add("AddButton", new Action<string, string, string, string, object>(AddButton));
+            Exports.Add("AddList", new Action<string, string, string, object, int, string, object>(AddList));
+            Exports.Add("AddCheckbox", new Action<string, string, string, string, bool, object>(AddCheckbox));
+            Exports.Add("AddSlider", new Action<string, string, string, string, int, object>(AddSlider));
+            Exports.Add("AddSpacer", new Action<string, string, string, string>(AddSpacer));
+            Exports.Add("AddSubmenuButton", new Action<string, string, string, string, string, object>(AddSubmenuButton));
+
+            // Modify Menu Items
+            Exports.Add("RemoveItem", new Action<string, string>(RemoveItem));
+
+            // Notifications
+            Exports.Add("Notify", new Action<string, string>(notifExp));
+        }
+        #endregion
+
+        #region Export Implementation Methods
+
+        /// <summary>
+        /// Creates a new dynamic menu
+        /// </summary>
+        /// <param name="menuId">Unique identifier for the menu</param>
+        /// <param name="menuTitle">Display title for the menu</param>
+        /// <param name="menuDescription">Menu description/subtitle</param>
+        /// <param name="callbackObj">Optional callback for menu open events</param>
+        private void CreateMenu(string menuId, string menuTitle, string menuDescription, object callbackObj)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] CreateMenu: menuId cannot be null or empty.");
+                return;
+            }
+
+            // Check for any ID conflicts
+            if (HasIdConflict(menuId, "CreateMenu"))
+            {
+                return;
+            }
+
+            // Apply defaults for optional parameters
+            if (string.IsNullOrEmpty(menuTitle))
+                menuTitle = "Menu";
+            if (string.IsNullOrEmpty(menuDescription))
+                menuDescription = "";
+
+            var newMenu = new Menu(Game.Player.Name, menuTitle)
+            {
+                MenuSubtitle = menuDescription
+            };
+            MenuController.AddMenu(newMenu);
+            DynamicMenus[menuId] = newMenu;
+
+            if (callbackObj != null)
+            {
+                // Handle both C# delegates and Lua functions
+                if (callbackObj is CallbackDelegate callback)
+                {
+                    newMenu.OnMenuOpen += (sender) =>
+                    {
+                        callback.Invoke();
+                    };
+                }
+                else
+                {
+                    // Handle Lua functions and dynamic callbacks
+                    newMenu.OnMenuOpen += (sender) =>
+                    {
+                        try
+                        {
+                            dynamic dynamicCallback = callbackObj;
+                            dynamicCallback();
+                        }
+                        catch (Exception ex)
+                        {
+                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking menu open callback for {menuId}: {ex.Message}");
+                        }
+                    };
+                }
+            }
+        }
+
+        /// <summary>
+        /// Displays notification to the player
+        /// </summary>
+        /// <param name="message">Notification message</param>
+        /// <param name="type">Notification type (error, info, success, or default)</param>
+        private void notifExp(string message, string type)
+        {
+            if (type == "error")
+            {
+                Notify.Error(message);
+            }
+            else if (type == "info")
+            {
+                Notify.Info(message);
+            }
+            else if (type == "success")
+            {
+                Notify.Success(message);
+            }
+            else
+            {
+                Notify.Alert(message);
+            }
+        }
+
+        /// <summary>
+        /// Opens a menu by ID
+        /// </summary>
+        /// <param name="menuId">Menu identifier</param>
+        private void OpenMenu(string menuId)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] OpenMenu: menuId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            menu.OpenMenu();
+        }
+
+        /// <summary>
+        /// Adds a button to a menu
+        /// </summary>
+        /// <param name="menuId">Target menu ID</param>
+        /// <param name="buttonId">Unique button identifier</param>
+        /// <param name="buttonLabel">Button display text</param>
+        /// <param name="buttonDescription">Button description</param>
+        /// <param name="callbackObj">Optional callback for button selection</param>
+        private void AddButton(string menuId, string buttonId, string buttonLabel, string buttonDescription, object callbackObj = null)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(buttonId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddButton: buttonId cannot be null or empty.");
+                return;
+            }
+
+            // Check for ID conflicts (menu names, other items)
+            if (HasIdConflict(buttonId, "AddButton"))
+            {
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            // Check for item conflicts within this menu
+            if (HasItemConflict(menu, buttonId, "AddButton"))
+            {
+                return;
+            }
+
+            // Apply defaults for optional parameters
+            if (string.IsNullOrEmpty(buttonLabel))
+                buttonLabel = "Button";
+            if (string.IsNullOrEmpty(buttonDescription))
+                buttonDescription = "";
+
+            var menuItem = new MenuItem(buttonLabel, buttonDescription)
+            {
+                ItemData = buttonId
+            };
+
+            if (callbackObj != null)
+            {
+                // Handle both C# delegates and Lua functions
+                if (callbackObj is CallbackDelegate callback)
+                {
+                    menu.OnItemSelect += (sender, item, index) =>
+                    {
+                        if (item == menuItem)
+                        {
+                            callback.Invoke();
+                        }
+                    };
+                }
+                else if (callbackObj is Func<object> luaCallback)
+                {
+                    menu.OnItemSelect += (sender, item, index) =>
+                    {
+                        if (item == menuItem)
+                        {
+                            try
+                            {
+                                luaCallback.Invoke();
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for button {buttonId}: {ex.Message}");
+                            }
+                        }
+                    };
+                }
+                else
+                {
+                    // Try to invoke as dynamic for other callback types
+                    menu.OnItemSelect += (sender, item, index) =>
+                    {
+                        if (item == menuItem)
+                        {
+                            try
+                            {
+                                dynamic dynamicCallback = callbackObj;
+                                dynamicCallback();
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking dynamic callback for button {buttonId}: {ex.Message}");
+                            }
+                        }
+                    };
+                }
+            }
+
+            menu.AddMenuItem(menuItem);
+            menu.RefreshIndex();
+        }
+
+        /// <summary>
+        /// Adds a list item to a menu
+        /// </summary>
+        /// <param name="menuId">Target menu ID</param>
+        /// <param name="listId">Unique list identifier</param>
+        /// <param name="listLabel">List display text</param>
+        /// <param name="options">List options as object array</param>
+        /// <param name="defaultIndex">Default selected index</param>
+        /// <param name="description">List description</param>
+        /// <param name="callbackObj">Optional callback for list changes</param>
+        private void AddList(string menuId, string listId, string listLabel, object options, int defaultIndex, string description, object callbackObj = null)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(listId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddList: listId cannot be null or empty.");
+                return;
+            }
+
+            // Check for ID conflicts (menu names, other items)
+            if (HasIdConflict(listId, "AddList"))
+            {
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            // Check for item conflicts within this menu
+            if (HasItemConflict(menu, listId, "AddList"))
+            {
+                return;
+            }
+
+            // Apply defaults for optional parameters
+            if (string.IsNullOrEmpty(listLabel))
+                listLabel = "List";
+            if (string.IsNullOrEmpty(description))
+                description = "";
+
+            List<string> optionsList;
+
+            // Handle different option input types
+            if (options is string jsonString)
+            {
+                // Legacy support for JSON string
+                optionsList = JsonConvert.DeserializeObject<List<string>>(jsonString);
+            }
+            else if (options is object[] objectArray)
+            {
+                // Convert object array to string list
+                optionsList = objectArray.Select(o => o?.ToString() ?? "").ToList();
+            }
+            else if (options is List<object> objectList)
+            {
+                // Convert object list to string list
+                optionsList = objectList.Select(o => o?.ToString() ?? "").ToList();
+            }
+            else if (options == null)
+            {
+                // Provide default empty list if options is null
+                optionsList = new List<string> { "Option 1", "Option 2" };
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] No options provided for list {listId}, using default options.");
+            }
+            else
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Invalid options type for list {listId}. Expected array or JSON string.");
+                return;
+            }
+
+            // Validate defaultIndex
+            if (defaultIndex < 0 || defaultIndex >= optionsList.Count)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Invalid defaultIndex {defaultIndex} for list {listId}. Using 0 instead.");
+                defaultIndex = 0;
+            }
+
+            var menuListItem = new MenuListItem(listLabel, optionsList, defaultIndex, description)
+            {
+                ItemData = listId
+            };
+
+            if (callbackObj != null)
+            {
+                // Handle both C# delegates and Lua functions
+                if (callbackObj is CallbackDelegate callback)
+                {
+                    // Listen for index changes (browsing through list)
+                    menu.OnListIndexChange += (sender, item, oldIndex, newIndex, itemIndex) =>
+                    {
+                        if (item == menuListItem)
+                        {
+                            var currentValue = optionsList[newIndex];
+                            var oldValue = optionsList[oldIndex];
+                            callback.Invoke(false, currentValue, newIndex, oldIndex);
+                        }
+                    };
+
+                    // Listen for item selection (pressing enter/select)
+                    menu.OnListItemSelect += (sender, item, listIndex, itemIndex) =>
+                    {
+                        if (item == menuListItem)
+                        {
+                            var selectedValue = optionsList[listIndex];
+                            callback.Invoke(true, selectedValue, listIndex, listIndex);
+                        }
+                    };
+                }
+                else
+                {
+                    // Handle Lua functions and dynamic callbacks
+                    menu.OnListIndexChange += (sender, item, oldIndex, newIndex, itemIndex) =>
+                    {
+                        if (item == menuListItem)
+                        {
+                            try
+                            {
+                                var currentValue = optionsList[newIndex];
+                                var oldValue = optionsList[oldIndex];
+                                dynamic dynamicCallback = callbackObj;
+                                dynamicCallback(false, currentValue, newIndex, oldIndex);
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for list {listId}: {ex.Message}");
+                            }
+                        }
+                    };
+
+                    menu.OnListItemSelect += (sender, item, listIndex, itemIndex) =>
+                    {
+                        if (item == menuListItem)
+                        {
+                            try
+                            {
+                                var selectedValue = optionsList[listIndex];
+                                dynamic dynamicCallback = callbackObj;
+                                dynamicCallback(true, selectedValue, listIndex, listIndex);
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for list {listId}: {ex.Message}");
+                            }
+                        }
+                    };
+                }
+            }
+
+            menu.AddMenuItem(menuListItem);
+            menu.RefreshIndex();
+        }
+
+        /// <summary>
+        /// Adds a checkbox to a menu
+        /// </summary>
+        /// <param name="menuId">Target menu ID</param>
+        /// <param name="checkboxId">Unique checkbox identifier</param>
+        /// <param name="checkboxLabel">Checkbox display text</param>
+        /// <param name="description">Checkbox description</param>
+        /// <param name="defaultValue">Default checked state</param>
+        /// <param name="callbackObj">Optional callback for checkbox changes</param>
+        private void AddCheckbox(string menuId, string checkboxId, string checkboxLabel, string description, bool defaultValue, object callbackObj = null)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddCheckbox: menuId cannot be null or empty.");
+                return;
+            }
+            if (string.IsNullOrEmpty(checkboxId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddCheckbox: checkboxId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            // Check for ID conflicts (menu names, other items)
+            if (HasIdConflict(checkboxId, "AddCheckbox"))
+            {
+                return;
+            }
+
+            // Check for item conflicts within this menu
+            if (HasItemConflict(menu, checkboxId, "AddCheckbox"))
+            {
+                return;
+            }
+
+            // Apply defaults for optional parameters
+            if (string.IsNullOrEmpty(checkboxLabel))
+                checkboxLabel = "Checkbox";
+            if (string.IsNullOrEmpty(description))
+                description = "";
+
+            var menuCheckboxItem = new MenuCheckboxItem(checkboxLabel, description, defaultValue)
+            {
+                ItemData = checkboxId
+            };
+
+            if (callbackObj != null)
+            {
+                // Handle both C# delegates and Lua functions
+                if (callbackObj is CallbackDelegate callback)
+                {
+                    menu.OnCheckboxChange += (sender, item, index, _checked) =>
+                    {
+                        if (item == menuCheckboxItem)
+                        {
+                            callback.Invoke(_checked);
+                        }
+                    };
+                }
+                else if (callbackObj is Func<object> luaCallback)
+                {
+                    menu.OnCheckboxChange += (sender, item, index, _checked) =>
+                    {
+                        if (item == menuCheckboxItem)
+                        {
+                            try
+                            {
+                                dynamic dynamicCallback = luaCallback;
+                                dynamicCallback(_checked);
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for checkbox {checkboxId}: {ex.Message}");
+                            }
+                        }
+                    };
+                }
+                else
+                {
+                    // Try to invoke as dynamic for other callback types
+                    menu.OnCheckboxChange += (sender, item, index, _checked) =>
+                    {
+                        if (item == menuCheckboxItem)
+                        {
+                            try
+                            {
+                                dynamic dynamicCallback = callbackObj;
+                                dynamicCallback(_checked);
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking dynamic callback for checkbox {checkboxId}: {ex.Message}");
+                            }
+                        }
+                    };
+                }
+            }
+
+            menu.AddMenuItem(menuCheckboxItem);
+            menu.RefreshIndex();
+        }
+
+        /// <summary>
+        /// Adds a slider to a menu (0-100% range)
+        /// </summary>
+        /// <param name="menuId">Target menu ID</param>
+        /// <param name="sliderId">Unique slider identifier</param>
+        /// <param name="sliderLabel">Slider display text</param>
+        /// <param name="description">Slider description</param>
+        /// <param name="defaultValue">Default slider value (0-100)</param>
+        /// <param name="callbackObj">Optional callback for slider changes</param>
+        private void AddSlider(string menuId, string sliderId, string sliderLabel, string description, int defaultValue, object callbackObj = null)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSlider: menuId cannot be null or empty.");
+                return;
+            }
+            if (string.IsNullOrEmpty(sliderId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSlider: sliderId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            // Check for ID conflicts (menu names, other items)
+            if (HasIdConflict(sliderId, "AddSlider"))
+            {
+                return;
+            }
+
+            // Check for item conflicts within this menu
+            if (HasItemConflict(menu, sliderId, "AddSlider"))
+            {
+                return;
+            }
+
+            // Apply defaults for optional parameters
+            if (string.IsNullOrEmpty(sliderLabel))
+                sliderLabel = "Slider";
+            if (string.IsNullOrEmpty(description))
+                description = "";
+
+            // Validate defaultValue range (assuming 0-10 range)
+            if (defaultValue < 0 || defaultValue > 10)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Invalid defaultValue {defaultValue} for slider {sliderId}. Using 0 instead.");
+                defaultValue = 0;
+            }
+
+            var menuSliderItem = new MenuSliderItem(sliderLabel, description, 0, 10, defaultValue, false)
+            {
+                ItemData = sliderId
+            };
+
+            if (callbackObj != null)
+            {
+                // Handle both C# delegates and Lua functions
+                if (callbackObj is CallbackDelegate callback)
+                {
+                    // Listen for position changes
+                    menu.OnSliderPositionChange += (sender, item, oldPosition, newPosition, itemIndex) =>
+                    {
+                        if (item == menuSliderItem)
+                        {
+                            callback.Invoke(oldPosition, newPosition);
+                        }
+                    };
+                }
+                else
+                {
+                    // Handle Lua functions and dynamic callbacks
+                    menu.OnSliderPositionChange += (sender, item, oldPosition, newPosition, itemIndex) =>
+                    {
+                        if (item == menuSliderItem)
+                        {
+                            try
+                            {
+                                dynamic dynamicCallback = callbackObj;
+                                dynamicCallback(oldPosition, newPosition);
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for slider {sliderId}: {ex.Message}");
+                            }
+                        }
+                    };
+                }
+            }
+
+            menu.AddMenuItem(menuSliderItem);
+            menu.RefreshIndex();
+        }
+
+        /// <summary>
+        /// Adds a spacer/separator to a menu
+        /// </summary>
+        /// <param name="menuId">Target menu ID</param>
+        /// <param name="spacerId">Unique spacer identifier</param>
+        /// <param name="spacerText">Spacer display text</param>
+        /// <param name="description">Optional spacer description</param>
+        private void AddSpacer(string menuId, string spacerId, string spacerText, string description)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSpacer: menuId cannot be null or empty.");
+                return;
+            }
+            if (string.IsNullOrEmpty(spacerId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSpacer: spacerId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            // Check for ID conflicts (menu names, other items)
+            if (HasIdConflict(spacerId, "AddSpacer"))
+            {
+                return;
+            }
+
+            // Check for item conflicts within this menu
+            if (HasItemConflict(menu, spacerId, "AddSpacer"))
+            {
+                return;
+            }
+
+            // Apply defaults for optional parameters
+            if (string.IsNullOrEmpty(spacerText))
+                spacerText = "---";
+            if (string.IsNullOrEmpty(description))
+                description = "";
+
+            var spacerItem = CommonFunctions.GetSpacerMenuItem(spacerText, description);
+            spacerItem.ItemData = spacerId;
+            menu.AddMenuItem(spacerItem);
+        }
+
+        /// <summary>
+        /// Refreshes a menu's display
+        /// </summary>
+        /// <param name="menuId">Target menu ID</param>
+        private void RefreshMenu(string menuId)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] RefreshMenu: menuId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            menu.RefreshIndex();
+        }
+
+        /// <summary>
+        /// Closes all open menus
+        /// </summary>
+        private void CloseAllMenus()
+        {
+            MenuController.CloseAllMenus();
+        }
+
+        /// <summary>
+        /// Closes a specific menu
+        /// </summary>
+        /// <param name="menuId">Menu ID to close</param>
+        private void CloseMenu(string menuId)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] CloseMenu: menuId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            if (menu.Visible)
+            {
+                menu.CloseMenu();
+            }
+        }
+
+        /// <summary>
+        /// Adds a submenu button to link a parent menu to a submenu
+        /// </summary>
+        /// <param name="parentMenuId">Parent menu ID</param>
+        /// <param name="buttonId">Unique button identifier</param>
+        /// <param name="submenuId">Submenu ID to link to</param>
+        /// <param name="buttonLabel">Button display text</param>
+        /// <param name="buttonDescription">Button description</param>
+        /// <param name="callbackObj">Optional callback for button selection</param>
+        private void AddSubmenuButton(string parentMenuId, string buttonId, string submenuId, string buttonLabel, string buttonDescription, object callbackObj = null)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(parentMenuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: parentMenuId cannot be null or empty.");
+                return;
+            }
+
+
+
+            if (string.IsNullOrEmpty(buttonId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: buttonId cannot be null or empty.");
+                return;
+            }
+            if (string.IsNullOrEmpty(submenuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: submenuId cannot be null or empty.");
+                return;
+            }
+
+            // Check for ID conflicts for buttonId
+            if (HasIdConflict(buttonId, "AddSubmenuButton"))
+            {
+                return;
+            }
+
+            // Verify submenu exists (either dynamic or built-in)
+            if (!DynamicMenus.ContainsKey(submenuId) && GetMenu(submenuId) == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: Submenu '{submenuId}' does not exist. Create it first.");
+                return;
+            }
+
+
+            Menu parentMenu = null;
+            if (!DynamicMenus.TryGetValue(parentMenuId, out parentMenu))
+            {
+                parentMenu = GetMenu(parentMenuId);
+            }
+
+            Menu submenu = null;
+            if (!DynamicMenus.TryGetValue(submenuId, out submenu))
+            {
+                submenu = GetMenu(submenuId);
+            }
+
+            if (parentMenu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Parent menu {parentMenuId} not found.");
+                return;
+            }
+
+            if (submenu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Submenu {submenuId} not found.");
+                return;
+            }
+
+            // Check for item conflicts within parent menu
+            if (HasItemConflict(parentMenu, buttonId, "AddSubmenuButton"))
+            {
+                return;
+            }
+
+            // Apply defaults for optional parameters
+            if (string.IsNullOrEmpty(buttonLabel))
+                buttonLabel = "Submenu";
+            if (string.IsNullOrEmpty(buttonDescription))
+                buttonDescription = "";
+
+            var submenuButton = new MenuItem(buttonLabel, buttonDescription)
+            {
+                Label = "→→→",
+                ItemData = buttonId
+            };
+
+            parentMenu.AddMenuItem(submenuButton);
+            MenuController.AddSubmenu(parentMenu, submenu);
+            MenuController.BindMenuItem(parentMenu, submenu, submenuButton);
+            submenu.RefreshIndex();
+
+            if (callbackObj != null)
+            {
+                // Handle both C# delegates and Lua functions
+                if (callbackObj is CallbackDelegate callback)
+                {
+                    parentMenu.OnItemSelect += (sender, item, index) =>
+                    {
+                        if (item == submenuButton)
+                        {
+                            callback.Invoke();
+                        }
+                    };
+                }
+                else if (callbackObj is Func<object> luaCallback)
+                {
+                    parentMenu.OnItemSelect += (sender, item, index) =>
+                    {
+                        if (item == submenuButton)
+                        {
+                            try
+                            {
+                                luaCallback.Invoke();
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking callback for submenu button {buttonLabel}: {ex.Message}");
+                            }
+                        }
+                    };
+                }
+                else
+                {
+                    // Try to invoke as dynamic for other callback types
+                    parentMenu.OnItemSelect += (sender, item, index) =>
+                    {
+                        if (item == submenuButton)
+                        {
+                            try
+                            {
+                                dynamic dynamicCallback = callbackObj;
+                                dynamicCallback();
+                            }
+                            catch (Exception ex)
+                            {
+                                CitizenFX.Core.Debug.WriteLine($"[vMenu] Error invoking dynamic callback for submenu button {buttonLabel}: {ex.Message}");
+                            }
+                        }
+                    };
+                }
+            }
+
+            parentMenu.RefreshIndex();
+        }
+
+        /// <summary>
+        /// Removes an item from a menu
+        /// </summary>
+        /// <param name="menuId">Target menu ID</param>
+        /// <param name="itemId">Item identifier to remove</param>
+        private void RemoveItem(string menuId, string itemId)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: menuId cannot be null or empty.");
+                return;
+            }
+            if (string.IsNullOrEmpty(itemId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: itemId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            // Find the item to remove, regardless of its type
+            var itemToRemove = menu.GetMenuItems().Find(item => item.ItemData as string == itemId);
+
+            if (itemToRemove != null)
+            {
+                menu.RemoveMenuItem(itemToRemove);
+            }
+            else
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Item with ID {itemId} not found in menu {menuId}.");
+            }
+        }
+
+        /// <summary>
+        /// Clears all items from a menu
+        /// </summary>
+        /// <param name="menuId">Target menu ID</param>
+        private void ClearMenu(string menuId)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] ClearMenu: menuId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            menu.ClearMenuItems();
+        }
+
+        /// <summary>
+        /// Checks if a menu exists
+        /// </summary>
+        /// <param name="menuId">Menu ID to check</param>
+        /// <returns>True if menu exists, false otherwise</returns>
+        private bool CheckMenu(string menuId)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] CheckMenu: menuId cannot be null or empty.");
+                return false;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                menu = GetMenu(menuId);
+            }
+
+            if (menu == null)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Deletes a dynamically created menu
+        /// </summary>
+        /// <param name="menuId">Menu ID to delete</param>
+        private void DeleteMenu(string menuId)
+        {
+            // Validate required parameters
+            if (string.IsNullOrEmpty(menuId))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] DeleteMenu: menuId cannot be null or empty.");
+                return;
+            }
+
+            Menu menu = null;
+            if (!DynamicMenus.TryGetValue(menuId, out menu))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Menu with ID {menuId} not found.");
+                return;
+            }
+
+            // Close the menu if it's currently open
+            if (menu.Visible)
+            {
+                menu.CloseMenu();
+            }
+
+            // Clear all menu items (handles all item cleanup including submenu buttons)
+            menu.ClearMenuItems();
+
+            // Remove from MenuController's menu collection
+            if (MenuController.Menus.Contains(menu))
+            {
+                MenuController.Menus.Remove(menu);
+            }
+
+            // Remove from dynamic menus dictionary
+            DynamicMenus.Remove(menuId);
+
+            // Set menu reference to null for garbage collection
+            menu = null;
+        }
+
+
+        /// <summary>
+        /// Dynamically finds built-in vMenu menus by ID with permission checking
+        /// </summary>
+        /// <param name="menuId">Menu identifier string</param>
+        /// <returns>Menu instance if found and permitted, null otherwise</returns>
+        private Menu GetMenu(string menuId)
+        {
+            // Handle core menu shortcuts first
+            switch (menuId.ToLower())
+            {
+                case "main": return Menu;
+                case "player": return PlayerSubmenu;
+                case "vehicle": return VehicleSubmenu;
+                case "world":
+                    return ((IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync)) ||
+                            (IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync))) ? WorldSubmenu : null;
+            }
+
+            // Dynamically search all registered menus
+            foreach (var menu in MenuController.Menus)
+            {
+                // Skip if this is a dynamic menu (user-created)
+                if (DynamicMenus.ContainsValue(menu)) continue;
+
+                // Try to match by menu title (converted to lowercase, spaces removed)
+                var normalizedTitle = menu.MenuTitle.ToLower().Replace(" ", "").Replace("-", "");
+                var normalizedId = menuId.ToLower().Replace(" ", "").Replace("-", "");
+
+                if (normalizedTitle.Contains(normalizedId) || normalizedId.Contains(normalizedTitle))
+                {
+                    // Basic permission check for known menu patterns
+                    if (IsMenuPermitted(menu, menuId.ToLower()))
+                    {
+                        return menu;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if a menu is permitted based on vMenu permissions
+        /// </summary>
+        /// <param name="menu">Menu to check</param>
+        /// <param name="menuId">Menu identifier</param>
+        /// <returns>True if permitted, false otherwise</returns>
+        private bool IsMenuPermitted(Menu menu, string menuId)
+        {
+            // Common permission patterns based on menu titles/IDs
+            return menuId switch
+            {
+                var id when id.Contains("player") && id.Contains("option") => IsAllowed(Permission.POMenu),
+                var id when id.Contains("online") && id.Contains("player") => IsAllowed(Permission.OPMenu),
+                var id when id.Contains("banned") => IsAllowed(Permission.OPUnban) || IsAllowed(Permission.OPViewBannedPlayers),
+                var id when id.Contains("personal") && id.Contains("vehicle") => IsAllowed(Permission.PVMenu),
+                var id when id.Contains("vehicle") && id.Contains("option") => IsAllowed(Permission.VOMenu),
+                var id when id.Contains("vehicle") && id.Contains("spawn") => IsAllowed(Permission.VSMenu),
+                var id when id.Contains("saved") && id.Contains("vehicle") => IsAllowed(Permission.SVMenu),
+                var id when id.Contains("player") && id.Contains("appearance") => IsAllowed(Permission.PAMenu),
+                var id when id.Contains("ped") && id.Contains("customization") => IsAllowed(Permission.PAMenu),
+                var id when id.Contains("time") => IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync),
+                var id when id.Contains("weather") => IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync),
+                var id when id.Contains("weapon") && id.Contains("option") => IsAllowed(Permission.WPMenu),
+                var id when id.Contains("weapon") && id.Contains("loadout") => IsAllowed(Permission.WLMenu),
+                var id when id.Contains("voice") => IsAllowed(Permission.VCMenu),
+                // Allow access to menus without specific restrictions
+                var id when id.Contains("recording") || id.Contains("misc") || id.Contains("about") => true,
+                // Default to allowing access for unrecognized menus
+                _ => true
+            };
+        }
+
+        #endregion
+    }
+}

--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -26,6 +26,16 @@ namespace vMenuClient
         /// </summary>
         private static Dictionary<string, Menu> DynamicMenus = new Dictionary<string, Menu>();
 
+        /// <summary>
+        /// List to store callbacks waiting for vMenu to be ready
+        /// </summary>
+        private static List<object> ReadyCallbacks = new List<object>();
+
+        /// <summary>
+        /// Flag indicating if vMenu is ready for external interactions
+        /// </summary>
+        private static bool IsVMenuReady = false;
+
         #region Helper Methods
 
         /// <summary>
@@ -125,14 +135,23 @@ namespace vMenuClient
         /// Retrieves a menu by ID from dynamic or built-in menus
         /// </summary>
         /// <param name="menuId">Menu identifier</param>
+        /// <param name="context">Error context</param>
         /// <returns>Menu instance if found, null otherwise</returns>
-        private Menu RetrieveMenu(string menuId)
+        private Menu RetrieveMenu(string menuId, string context = null)
         {
             if (DynamicMenus.TryGetValue(menuId, out Menu menu))
             {
                 return menu;
             }
-            return GetMenu(menuId);
+
+            menu = GetMenu(menuId);
+
+            if (menu == null && !string.IsNullOrEmpty(context))
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] {context}: Menu with ID '{menuId}' not found.");
+            }
+
+            return menu;
         }
 
         /// <summary>
@@ -175,9 +194,6 @@ namespace vMenuClient
                             break;
                         case 4:
                             dynamicCallback(args[0], args[1], args[2], args[3]);
-                            break;
-                        default:
-                            CitizenFX.Core.Debug.WriteLine($"[vMenu] Callback for {itemId} has unsupported number of arguments: {args.Length}");
                             break;
                     }
                 }
@@ -251,8 +267,12 @@ namespace vMenuClient
             {
                 if (menuItem == item)
                 {
-                    var currentValue = options[newIndex];
-                    SafeInvokeCallback(callbackObj, itemId, false, currentValue, newIndex, oldIndex);
+                    // Bounds check to prevent ArgumentOutOfRangeException
+                    if (newIndex >= 0 && newIndex < options.Count && oldIndex >= 0 && oldIndex < options.Count)
+                    {
+                        var currentValue = options[newIndex];
+                        SafeInvokeCallback(callbackObj, itemId, false, currentValue, newIndex, oldIndex);
+                    }
                 }
             };
 
@@ -261,8 +281,12 @@ namespace vMenuClient
             {
                 if (menuItem == item)
                 {
-                    var selectedValue = options[listIndex];
-                    SafeInvokeCallback(callbackObj, itemId, true, selectedValue, listIndex, listIndex);
+                    // Bounds check to prevent ArgumentOutOfRangeException
+                    if (listIndex >= 0 && listIndex < options.Count)
+                    {
+                        var selectedValue = options[listIndex];
+                        SafeInvokeCallback(callbackObj, itemId, true, selectedValue, listIndex, listIndex);
+                    }
                 }
             };
         }
@@ -331,6 +355,19 @@ namespace vMenuClient
         public void InitializeDynamicMenuExports()
         {
             RegisterDynamicMenuExports();
+            RegisterReadyEventHandler();
+        }
+
+        /// <summary>
+        /// Registers event handler to listen for vMenu ready state
+        /// </summary>
+        private void RegisterReadyEventHandler()
+        {
+            // Listen for vMenu initialization complete
+            EventHandlers["vMenu:SetupTickFunctions"] += new Action(() =>
+            {
+                TriggerReady();
+            });
         }
 
         /// <summary>
@@ -366,6 +403,10 @@ namespace vMenuClient
             Exports.Add("GetAllMenuIds", new Func<string[]>(GetAllMenuIds));
             Exports.Add("GetMenu", new Func<string, object>(GetMenuExport));
             Exports.Add("IsMenuPermitted", new Func<string, bool>(IsMenuPermittedExport));
+
+            // Ready State Management
+            Exports.Add("OnReady", new Action<object>(OnReadyExport));
+            Exports.Add("IsReady", new Func<bool>(IsReadyExport));
         }
 
         #endregion
@@ -434,13 +475,8 @@ namespace vMenuClient
         {
             if (!ValidateParameter(menuId, "menuId", "OpenMenu")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] OpenMenu: Menu with ID '{menuId}' not found. Available menus: {string.Join(", ", GetAllMenuIds())}");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "OpenMenu");
+            if (menu == null) return;
 
             // Close all currently open menus before opening the new one
             MenuController.CloseAllMenus();
@@ -479,12 +515,8 @@ namespace vMenuClient
             if (!ValidateParameter(buttonId, "buttonId", "AddButton")) return;
             if (HasIdConflict(buttonId, "AddButton")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddButton: Menu with ID {menuId} not found.");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "AddButton");
+            if (menu == null) return;
 
             if (HasItemConflict(menu, buttonId, "AddButton")) return;
 
@@ -520,12 +552,8 @@ namespace vMenuClient
             if (!ValidateParameter(listId, "listId", "AddList")) return;
             if (HasIdConflict(listId, "AddList")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddList: Menu with ID {menuId} not found.");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "AddList");
+            if (menu == null) return;
 
             if (HasItemConflict(menu, listId, "AddList")) return;
 
@@ -596,12 +624,8 @@ namespace vMenuClient
             if (!ValidateParameter(menuId, "menuId", "AddCheckbox")) return;
             if (!ValidateParameter(checkboxId, "checkboxId", "AddCheckbox")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddCheckbox: Menu with ID {menuId} not found.");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "AddCheckbox");
+            if (menu == null) return;
 
             if (HasIdConflict(checkboxId, "AddCheckbox")) return;
             if (HasItemConflict(menu, checkboxId, "AddCheckbox")) return;
@@ -636,12 +660,8 @@ namespace vMenuClient
             if (!ValidateParameter(menuId, "menuId", "AddSlider")) return;
             if (!ValidateParameter(sliderId, "sliderId", "AddSlider")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSlider: Menu with ID {menuId} not found.");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "AddSlider");
+            if (menu == null) return;
 
             if (HasIdConflict(sliderId, "AddSlider")) return;
             if (HasItemConflict(menu, sliderId, "AddSlider")) return;
@@ -681,12 +701,8 @@ namespace vMenuClient
             if (!ValidateParameter(menuId, "menuId", "AddSpacer")) return;
             if (!ValidateParameter(spacerId, "spacerId", "AddSpacer")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSpacer: Menu with ID {menuId} not found.");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "AddSpacer");
+            if (menu == null) return;
 
             if (HasIdConflict(spacerId, "AddSpacer")) return;
             if (HasItemConflict(menu, spacerId, "AddSpacer")) return;
@@ -710,12 +726,8 @@ namespace vMenuClient
         {
             if (!ValidateParameter(menuId, "menuId", "RefreshMenu")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] RefreshMenu: Menu with ID {menuId} not found.");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "RefreshMenu");
+            if (menu == null) return;
 
             menu.RefreshIndex();
         }
@@ -736,12 +748,8 @@ namespace vMenuClient
         {
             if (!ValidateParameter(menuId, "menuId", "CloseMenu")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] CloseMenu: Menu with ID {menuId} not found.");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "CloseMenu");
+            if (menu == null) return;
 
             if (menu.Visible)
             {
@@ -773,20 +781,11 @@ namespace vMenuClient
                 return;
             }
 
-            Menu parentMenu = RetrieveMenu(parentMenuId);
-            Menu submenu = RetrieveMenu(submenuId);
+            Menu parentMenu = RetrieveMenu(parentMenuId, "AddSubmenuButton (parent)");
+            if (parentMenu == null) return;
 
-            if (parentMenu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: Parent menu {parentMenuId} not found.");
-                return;
-            }
-
-            if (submenu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] AddSubmenuButton: Submenu {submenuId} not found.");
-                return;
-            }
+            Menu submenu = RetrieveMenu(submenuId, "AddSubmenuButton (submenu)");
+            if (submenu == null) return;
 
             if (HasItemConflict(parentMenu, buttonId, "AddSubmenuButton")) return;
 
@@ -826,12 +825,8 @@ namespace vMenuClient
                 return;
             }
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] RemoveItem: Menu with ID {menuId} not found.");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "RemoveItem");
+            if (menu == null) return;
 
             var items = menu.GetMenuItems();
 
@@ -843,7 +838,17 @@ namespace vMenuClient
                     // Silent fail for out of range index (used for clearing menus in loops)
                     return;
                 }
-                menu.RemoveMenuItem(items[index]);
+                try
+                {
+                    menu.RemoveMenuItem(items[index]);
+                }
+                catch (ArgumentOutOfRangeException ex)
+                {
+                    CitizenFX.Core.Debug.WriteLine($"[vMenu] ArgumentOutOfRangeException in RemoveItem for menu {menuId}, index {index}:");
+                    CitizenFX.Core.Debug.WriteLine($"[vMenu] Items count: {items.Count}");
+                    CitizenFX.Core.Debug.WriteLine($"[vMenu] Message: {ex.Message}");
+                    CitizenFX.Core.Debug.WriteLine($"[vMenu] Stack trace: {ex.StackTrace}");
+                }
             }
             // Otherwise treat as string (ID-based removal)
             else if (itemIdOrIndex is string itemId)
@@ -880,12 +885,8 @@ namespace vMenuClient
         {
             if (!ValidateParameter(menuId, "menuId", "ClearMenu")) return;
 
-            Menu menu = RetrieveMenu(menuId);
-            if (menu == null)
-            {
-                CitizenFX.Core.Debug.WriteLine($"[vMenu] ClearMenu: Menu with ID '{menuId}' not found. Available menus: {string.Join(", ", GetAllMenuIds())}");
-                return;
-            }
+            Menu menu = RetrieveMenu(menuId, "ClearMenu");
+            if (menu == null) return;
 
             menu.ClearMenuItems();
         }
@@ -982,7 +983,17 @@ namespace vMenuClient
         /// <returns>Menu instance as object if found, null otherwise</returns>
         private object GetMenuExport(string menuId)
         {
-            return GetMenu(menuId);
+            try
+            {
+                return GetMenu(menuId);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] ArgumentOutOfRangeException in GetMenuExport for {menuId}:");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Message: {ex.Message}");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Stack trace: {ex.StackTrace}");
+                return null;
+            }
         }
 
         /// <summary>
@@ -1000,15 +1011,24 @@ namespace vMenuClient
             }
 
             // Add built-in menu IDs based on their subtitles (avoid duplicates)
-            var uniqueMenus = MenuController.Menus.GroupBy(m => m.MenuSubtitle ?? m.MenuTitle).Select(g => g.First()).ToList();
-            foreach (var menu in uniqueMenus)
+            try
             {
-                // Skip dynamic menus (already added above)
-                if (DynamicMenus.ContainsValue(menu)) continue;
+                var uniqueMenus = MenuController.Menus.GroupBy(m => m.MenuSubtitle ?? m.MenuTitle).Select(g => g.First()).ToList();
+                foreach (var menu in uniqueMenus)
+                {
+                    // Skip dynamic menus (already added above)
+                    if (DynamicMenus.ContainsValue(menu)) continue;
 
-                var menuIdentifier = menu.MenuSubtitle ?? menu.MenuTitle ?? "";
-                var normalizedTitle = menuIdentifier.ToLower().Replace(" ", "-");
-                menuIds.Add(normalizedTitle);
+                    var menuIdentifier = menu.MenuSubtitle ?? menu.MenuTitle ?? "";
+                    var normalizedTitle = menuIdentifier.ToLower().Replace(" ", "-");
+                    menuIds.Add(normalizedTitle);
+                }
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] ArgumentOutOfRangeException in GetAllMenuIds:");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Message: {ex.Message}");
+                CitizenFX.Core.Debug.WriteLine($"[vMenu] Stack trace: {ex.StackTrace}");
             }
 
             // Remove duplicates and sort
@@ -1037,6 +1057,66 @@ namespace vMenuClient
             }
 
             return IsMenuPermitted(menu, normalizedId);
+        }
+
+        /// <summary>
+        /// Registers a callback to be invoked when vMenu is ready
+        /// If vMenu is already ready, the callback is invoked immediately
+        /// Note: Callbacks that perform asynchronous work (menu modifications, waits, etc.)
+        /// should wrap their logic in Citizen.CreateThread() to prevent serialization errors
+        /// Example: exports.vMenu:OnReady(function() Citizen.CreateThread(setupMenu) end)
+        /// </summary>
+        /// <param name="callbackObj">Callback function to invoke</param>
+        private void OnReadyExport(object callbackObj)
+        {
+            if (callbackObj == null)
+            {
+                CitizenFX.Core.Debug.WriteLine("[vMenu] OnReady: callback cannot be null.");
+                return;
+            }
+
+            if (IsVMenuReady)
+            {
+                // vMenu is already ready, invoke callback immediately
+                SafeInvokeCallback(callbackObj, "OnReady");
+            }
+            else
+            {
+                // vMenu not ready yet, queue the callback
+                ReadyCallbacks.Add(callbackObj);
+            }
+        }
+
+        /// <summary>
+        /// Checks if vMenu is ready for external interactions
+        /// </summary>
+        /// <returns>True if ready, false otherwise</returns>
+        private bool IsReadyExport()
+        {
+            return IsVMenuReady;
+        }
+
+        /// <summary>
+        /// Marks vMenu as ready and invokes all queued callbacks
+        /// This should be called when vMenu initialization is complete
+        /// </summary>
+        public void TriggerReady()
+        {
+            if (IsVMenuReady)
+            {
+                return; // Already triggered
+            }
+
+            IsVMenuReady = true;
+
+            // Invoke all queued callbacks
+            foreach (var callbackObj in ReadyCallbacks)
+            {
+                SafeInvokeCallback(callbackObj, "OnReady");
+            }
+
+            // Clear the callbacks list
+            ReadyCallbacks.Clear();
         }
 
         /// <summary>

--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -1127,33 +1127,146 @@ namespace vMenuClient
         /// <returns>True if permitted, false otherwise</returns>
         private bool IsMenuPermitted(Menu menu, string menuId)
         {
-            // Common permission patterns based on menu titles/IDs
-            return menuId switch
+            // Check direct menu mappings first
+            if (IsDirectMenuMapping(menuId, out bool permitted))
             {
-                // Direct menu mappings
-                "player-options" => IsAllowed(Permission.POMenu),
-                "online-players" => IsAllowed(Permission.OPMenu),
-                "personal-vehicle-options" => IsAllowed(Permission.PVMenu),
-                "vehicle-options" => IsAllowed(Permission.VOMenu),
-                "vehicle-spawner" => IsAllowed(Permission.VSMenu),
-                "weapon-options" => IsAllowed(Permission.WPMenu),
-                "voice-chat-settings" => IsAllowed(Permission.VCMenu),
-                "player-appearance" or "character-appearance-options" or "mp-ped-customization" => IsAllowed(Permission.PAMenu),
+                return permitted;
+            }
 
-                // Pattern-based menu checks
-                var id when id.Contains("banned-players") => IsAllowed(Permission.OPUnban) || IsAllowed(Permission.OPViewBannedPlayers),
-                var id when id.Contains("saved") && id.Contains("vehicle") => IsAllowed(Permission.SVMenu),
-                var id when id.Contains("weapon-loadouts") => IsAllowed(Permission.WLMenu),
-                var id when id.Contains("time") => IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync),
-                var id when id.Contains("weather") => IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync),
-                var id when id == "world" || id.Contains("world") => IsWorldMenuPermitted(),
+            // Check pattern-based menus
+            if (IsPatternBasedMenu(menuId, out permitted))
+            {
+                return permitted;
+            }
 
-                // Unrestricted menus
-                var id when id.Contains("recording-options") || id.Contains("misc-settings") || id.Contains("about-vmenu") => true,
+            // Check unrestricted menus
+            if (IsUnrestrictedMenu(menuId))
+            {
+                return true;
+            }
 
-                // Default to allowing access for unrecognized menus
-                _ => true
-            };
+            // Default to allowing access for unrecognized menus
+            return true;
+        }
+
+        /// <summary>
+        /// Checks direct menu ID mappings to permissions
+        /// </summary>
+        private bool IsDirectMenuMapping(string menuId, out bool permitted)
+        {
+            permitted = false;
+
+            switch (menuId)
+            {
+                case "player-options":
+                    permitted = IsAllowed(Permission.POMenu);
+                    return true;
+                case "online-players":
+                    permitted = IsAllowed(Permission.OPMenu);
+                    return true;
+                case "personal-vehicle-options":
+                    permitted = IsAllowed(Permission.PVMenu);
+                    return true;
+                case "vehicle-options":
+                    permitted = IsAllowed(Permission.VOMenu);
+                    return true;
+                case "vehicle-spawner":
+                    permitted = IsAllowed(Permission.VSMenu);
+                    return true;
+                case "weapon-options":
+                    permitted = IsAllowed(Permission.WPMenu);
+                    return true;
+                case "voice-chat-settings":
+                    permitted = IsAllowed(Permission.VCMenu);
+                    return true;
+                case "player-appearance":
+                case "character-appearance-options":
+                case "mp-ped-customization":
+                    permitted = IsAllowed(Permission.PAMenu);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Checks pattern-based menu permissions (menus with dynamic IDs)
+        /// </summary>
+        private bool IsPatternBasedMenu(string menuId, out bool permitted)
+        {
+            permitted = false;
+
+            if (menuId.Contains("banned-players"))
+            {
+                permitted = IsBannedPlayersMenuPermitted();
+                return true;
+            }
+
+            if (menuId.Contains("saved") && menuId.Contains("vehicle"))
+            {
+                permitted = IsAllowed(Permission.SVMenu);
+                return true;
+            }
+
+            if (menuId.Contains("weapon-loadouts"))
+            {
+                permitted = IsAllowed(Permission.WLMenu);
+                return true;
+            }
+
+            if (menuId.Contains("time"))
+            {
+                permitted = IsTimeMenuPermitted();
+                return true;
+            }
+
+            if (menuId.Contains("weather"))
+            {
+                permitted = IsWeatherMenuPermitted();
+                return true;
+            }
+
+            if (menuId == "world" || menuId.Contains("world"))
+            {
+                permitted = IsWorldMenuPermitted();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if a menu is unrestricted (always accessible)
+        /// </summary>
+        private bool IsUnrestrictedMenu(string menuId)
+        {
+            return menuId.Contains("recording-options") ||
+                   menuId.Contains("misc-settings") ||
+                   menuId.Contains("about-vmenu");
+        }
+
+        /// <summary>
+        /// Checks if the banned players menu is permitted
+        /// </summary>
+        private bool IsBannedPlayersMenuPermitted()
+        {
+            return IsAllowed(Permission.OPUnban) || IsAllowed(Permission.OPViewBannedPlayers);
+        }
+
+        /// <summary>
+        /// Checks if the time menu is permitted
+        /// </summary>
+        private bool IsTimeMenuPermitted()
+        {
+            return IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync);
+        }
+
+        /// <summary>
+        /// Checks if the weather menu is permitted
+        /// </summary>
+        private bool IsWeatherMenuPermitted()
+        {
+            return IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync);
         }
 
         /// <summary>

--- a/vMenu/Exports.cs
+++ b/vMenu/Exports.cs
@@ -125,6 +125,9 @@ namespace vMenuClient
 
             // Notifications
             Exports.Add("Notify", new Action<string, string>(notifExp));
+
+            // Menu Information
+            Exports.Add("GetAllMenuIds", new Func<string[]>(GetAllMenuIds));
         }
         #endregion
 
@@ -1151,26 +1154,14 @@ namespace vMenuClient
         /// <returns>Menu instance if found and permitted, null otherwise</returns>
         private Menu GetMenu(string menuId)
         {
-            // Handle core menu shortcuts first
-            switch (menuId.ToLower())
+            // Search all registered menus (built-in and dynamic) - find first matching unique menu
+            var uniqueMenus = MenuController.Menus.GroupBy(m => m.MenuSubtitle ?? m.MenuTitle).Select(g => g.First()).ToList();
+            foreach (var menu in uniqueMenus)
             {
-                case "main": return Menu;
-                case "player": return PlayerSubmenu;
-                case "vehicle": return VehicleSubmenu;
-                case "world":
-                    return ((IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync)) ||
-                            (IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync))) ? WorldSubmenu : null;
-            }
-
-            // Dynamically search all registered menus
-            foreach (var menu in MenuController.Menus)
-            {
-                // Skip if this is a dynamic menu (user-created)
-                if (DynamicMenus.ContainsValue(menu)) continue;
-
-                // Try to match by menu title (converted to lowercase, spaces removed)
-                var normalizedTitle = menu.MenuTitle.ToLower().Replace(" ", "").Replace("-", "");
-                var normalizedId = menuId.ToLower().Replace(" ", "").Replace("-", "");
+                // Try to match by menu subtitle (or title if subtitle is null)
+                var menuIdentifier = menu.MenuSubtitle ?? menu.MenuTitle ?? "";
+                var normalizedTitle = menuIdentifier.ToLower().Replace(" ", "-");
+                var normalizedId = menuId.ToLower().Replace(" ", "-");
 
                 if (normalizedTitle.Contains(normalizedId) || normalizedId.Contains(normalizedTitle))
                 {
@@ -1186,6 +1177,40 @@ namespace vMenuClient
         }
 
         /// <summary>
+        /// Export function to get all available menu IDs
+        /// </summary>
+        /// <returns>Array of menu IDs that can be accessed through GetMenu</returns>
+        private string[] GetAllMenuIds()
+        {
+            var menuIds = new List<string>();
+
+            // Add dynamic menu IDs
+            foreach (var kvp in DynamicMenus)
+            {
+                menuIds.Add(kvp.Key);
+            }
+
+            // Add built-in menu IDs based on their subtitles (avoid duplicates)
+            var uniqueMenus = MenuController.Menus.GroupBy(m => m.MenuSubtitle ?? m.MenuTitle).Select(g => g.First()).ToList();
+            foreach (var menu in uniqueMenus)
+            {
+                // Skip dynamic menus (already added above)
+                if (DynamicMenus.ContainsValue(menu)) continue;
+
+                // Check if menu is permitted
+                var menuIdentifier = menu.MenuSubtitle ?? menu.MenuTitle ?? "";
+                var normalizedTitle = menuIdentifier.ToLower().Replace(" ", "-");
+                if (IsMenuPermitted(menu, normalizedTitle))
+                {
+                    menuIds.Add(normalizedTitle);
+                }
+            }
+
+            // Remove duplicates and sort
+            return menuIds.Distinct().OrderBy(id => id).ToArray();
+        }
+
+        /// <summary>
         /// Checks if a menu is permitted based on vMenu permissions
         /// </summary>
         /// <param name="menu">Menu to check</param>
@@ -1196,22 +1221,24 @@ namespace vMenuClient
             // Common permission patterns based on menu titles/IDs
             return menuId switch
             {
-                var id when id.Contains("player") && id.Contains("option") => IsAllowed(Permission.POMenu),
-                var id when id.Contains("online") && id.Contains("player") => IsAllowed(Permission.OPMenu),
-                var id when id.Contains("banned") => IsAllowed(Permission.OPUnban) || IsAllowed(Permission.OPViewBannedPlayers),
-                var id when id.Contains("personal") && id.Contains("vehicle") => IsAllowed(Permission.PVMenu),
-                var id when id.Contains("vehicle") && id.Contains("option") => IsAllowed(Permission.VOMenu),
-                var id when id.Contains("vehicle") && id.Contains("spawn") => IsAllowed(Permission.VSMenu),
+                "player-options" => IsAllowed(Permission.POMenu),
+                "online-players" => IsAllowed(Permission.OPMenu),
+                var id when id.Contains("banned-players") => IsAllowed(Permission.OPUnban) || IsAllowed(Permission.OPViewBannedPlayers),
+                "personal-vehicle-options" => IsAllowed(Permission.PVMenu),
+                "vehicle-options" => IsAllowed(Permission.VOMenu),
+                "vehicle-spawner" => IsAllowed(Permission.VSMenu),
                 var id when id.Contains("saved") && id.Contains("vehicle") => IsAllowed(Permission.SVMenu),
-                var id when id.Contains("player") && id.Contains("appearance") => IsAllowed(Permission.PAMenu),
-                var id when id.Contains("ped") && id.Contains("customization") => IsAllowed(Permission.PAMenu),
+                "player-appearance" or "character-appearance-options" => IsAllowed(Permission.PAMenu),
+                "mp-ped-customization" => IsAllowed(Permission.PAMenu),
                 var id when id.Contains("time") => IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync),
                 var id when id.Contains("weather") => IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync),
-                var id when id.Contains("weapon") && id.Contains("option") => IsAllowed(Permission.WPMenu),
-                var id when id.Contains("weapon") && id.Contains("loadout") => IsAllowed(Permission.WLMenu),
-                var id when id.Contains("voice") => IsAllowed(Permission.VCMenu),
+                var id when id == "world" || id.Contains("world") => (IsAllowed(Permission.TOMenu) && GetSettingsBool(Setting.vmenu_enable_time_sync)) ||
+                                                                     (IsAllowed(Permission.WOMenu) && GetSettingsBool(Setting.vmenu_enable_weather_sync)),
+                "weapon-options" => IsAllowed(Permission.WPMenu),
+                var id when id.Contains("weapon-loadouts") => IsAllowed(Permission.WLMenu),
+                "voice-chat-settings" => IsAllowed(Permission.VCMenu),
                 // Allow access to menus without specific restrictions
-                var id when id.Contains("recording") || id.Contains("misc") || id.Contains("about") => true,
+                var id when id.Contains("recording-options") || id.Contains("misc-settings") || id.Contains("about-vmenu") => true,
                 // Default to allowing access for unrecognized menus
                 _ => true
             };

--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -17,7 +17,7 @@ using static vMenuShared.PermissionsManager;
 
 namespace vMenuClient
 {
-    public class MainMenu : BaseScript
+    public partial class MainMenu : BaseScript
     {
         #region Variables
 
@@ -345,6 +345,9 @@ namespace vMenuClient
 
             // Request server state from the server.
             TriggerServerEvent("vMenu:RequestServerState");
+
+            // Initialize dynamic menu exports
+            InitializeDynamicMenuExports();
         }
 
         #region Infinity bits


### PR DESCRIPTION
## Add Client Exports

I've been using my own build of vMenu with exports for years to let external Lua resources modify the menu. This makes it easy to create addon systems that can be maintained, updated, or removed separately without touching vMenu's core code.

This PR adds a single `Exports.cs` file that exposes client exports so you can create your own menus with MenuAPI and modify existing vMenu menus. External resources can plug into vMenu and add their own features.

**Example plugin with full export documentation:** https://github.com/tommy141x/vmenu-cinematic-cam  
This documents all available exports and their usage/parameters.

**Video demo:** https://www.youtube.com/watch?v=WmI7_X3snmc  
The demo showcases my custom framework plugin, ERS integration plugin, EUP plugin, and the cinematic camera plugin (linked above) all running together.

You can also test it live on my server at `178.156.146.100` (or `fivem://connect/kqj4l6`)

I think it could let vMenu have its own plugin ecosystem where people create and share addons. Whether you want to implement it this way or not, I figured I'd share what I've been using since it's worked well for me.