### PR TITLE
Fixing a JSON crash on saved weapon loadout data

### DIFF
--- a/vMenu/menus/WeaponLoadouts.cs
+++ b/vMenu/menus/WeaponLoadouts.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 
 using CitizenFX.Core;
 


### PR DESCRIPTION
Not sure how it happens but some clients get this error which persists across servers running different game builds and other data. Somehow their client sided data is corrupted, this code just provides a quick fix so that it doesn't crash building the menu making vMenu unusable for that client.