### PR TITLE
Added support for addon weapons being correctly saved to loadouts

### DIFF
--- a/vMenu/menus/WeaponOptions.cs
+++ b/vMenu/menus/WeaponOptions.cs
@@ -502,6 +502,7 @@ namespace vMenuClient.menus
             #region Loop through all weapons, create menus for them and add all menu items and handle events.
             foreach (var weapon in ValidWeapons.WeaponList)
             {
+                if (!ValidWeapons.weaponNames.ContainsKey(weapon.SpawnName)) continue;
                 var cat = (uint)GetWeapontypeGroup(weapon.Hash);
                 if (!string.IsNullOrEmpty(weapon.Name) && IsAllowed(weapon.Perm))
                 {


### PR DESCRIPTION
By editing the ValidWeapons.cs and the WeaponOptions.cs, i added support for addon weapons being correctly saved to custom made loadouts. Of course they are also getting correctly loaded, when loading the loadout. 

It works dynamically. If the users are adding addon weapons into the addons.json file, these weapons automatically get the feature to be saved and loaded correctly from the custom made loadouts :)