### PR TITLE
Added support for addon weapons being correctly saved to loadouts 

### DIFF
--- a/vMenu/data/ValidWeapon.cs
+++ b/vMenu/data/ValidWeapon.cs
@@ -101,7 +101,6 @@ namespace vMenuClient.data
             }
             return _components;
         }
-
         private static void CreateWeaponsList()
         {
             _weaponsList.Clear();

--- a/vMenu/menus/WeaponOptions.cs
+++ b/vMenu/menus/WeaponOptions.cs
@@ -895,7 +895,6 @@ namespace vMenuClient.menus
             addonWeaponsMenu.OnMenuOpen += (sender) => { OnIndexChange(sender, sender.GetCurrentMenuItem()); };
         }
 
-
         #endregion
 
         /// <summary>


### PR DESCRIPTION
By editing the ValidWeapons.cs and the WeaponOptions.cs, i added support for addon weapons being correctly saved to custom made loadouts. Of course they are also getting correctly loaded, when loading the loadout.

It works dynamically. If the users are adding addon weapons into the addons.json file, these weapons automatically get the feature to be saved and loaded correctly from the custom made loadouts :)

**Deleted previous pull request because a file was missing :)**