### PR TITLE
Bumps MenuAPI to 3.2.4

### DIFF
--- a/vMenu/vMenuClient.csproj
+++ b/vMenu/vMenuClient.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MenuAPI.FiveM" Version="3.2.2" />
+    <PackageReference Include="MenuAPI.FiveM" Version="3.2.4" />
 
     <Reference Include="Microsoft.CSharp" />
     


### PR DESCRIPTION
In title update 3788, Control values <0 or >402 are defaulted back to 0 in CONTROL_* natives, which is INPUT_NEXT_CAMERA (V). This has been addessed in MenuAPI 3.2.4 such that `-1` properly disables the menu toggle key checks.