### PR TITLE
fix(ci): truncate Discord commit field to avoid 400 on long messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,6 +246,7 @@ jobs:
         shell: bash
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
             echo "DISCORD_WEBHOOK_URL not configured, skipping."
@@ -283,6 +284,14 @@ jobs:
           SHA="${{ github.sha }}"
           SHORT_SHA="${SHA:0:7}"
 
+          # Discord caps embed field values at 1024 chars. Use only the commit
+          # subject (first line) and truncate it so the payload is never rejected
+          # with HTTP 400 on long, multi-line (e.g. squash-merged) messages.
+          COMMIT_SUBJECT=$(printf '%s' "$COMMIT_MSG" | head -n 1)
+          if [ "${#COMMIT_SUBJECT}" -gt 256 ]; then
+            COMMIT_SUBJECT="${COMMIT_SUBJECT:0:253}..."
+          fi
+
           PAYLOAD=$(jq -n \
             --arg  title       "vMenu (v${DISPLAY_VERSION})" \
             --arg  desc        "$STATUS_TEXT" \
@@ -294,7 +303,7 @@ jobs:
             --arg  link_url    "$LINK_URL" \
             --arg  short_sha   "$SHORT_SHA" \
             --arg  commit_url  "https://github.com/${{ github.repository }}/commit/${{ github.sha }}" \
-            --arg  commit_msg  "${{ github.event.head_commit.message }}" \
+            --arg  commit_msg  "$COMMIT_SUBJECT" \
             '{
               embeds: [{
                 title:       $title,


### PR DESCRIPTION
## Problem

The `Discord Notification` job failed on the latest master CI/CD run ([run 27018095845](https://github.com/TomGrobbe/vMenu/actions/runs/27018095845/job/79738635729)) with:

```
curl: (22) The requested URL returned error: 400
```

The build, release, and tag all succeeded (v3.8.14 published fine); only the notification step broke.

## Root cause

The "Commit" embed field was built from the full commit message (`github.event.head_commit.message`). For the squash-merged commit `0df96a4`, that message is 975 characters (it includes the entire PR body plus the co-author trailer). Combined with the `` [`sha`](commit_url) — `` link prefix (about 96 chars), the field value reached roughly 1071 characters, which exceeds Discord's 1024-character limit for embed field values. Discord rejects the payload with HTTP 400, and curl's `-f` flag turns that into exit code 22.

## Fix

- Use only the commit subject (first line) instead of the whole message.
- Truncate it to 256 chars as a safety cap (with an ellipsis), so the payload can never exceed the limit.
- Pass the message via the `COMMIT_MSG` environment variable instead of interpolating `${{ github.event.head_commit.message }}` directly into the shell script. The previous direct interpolation would also break the script if a commit subject ever contained a double quote (a latent shell-injection / quoting bug).

No other steps were changed.
