### PR TITLE
fix: saved weapon loadout permissions

### DIFF
--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -2825,9 +2825,14 @@ namespace vMenuClient
                 {
                     Game.PlayerPed.Weapons.RemoveAll();
                 }
+                
+                // Resolve permission by weapon name instead of using the saved Perm value.
+                // Permission enum values change as new weapons are added, so an old saved loadout can deserialize to the wrong permission.
+                Permission ResolveCurrentPerm(ValidWeapon wp) =>
+                    ValidWeapons.weaponPermissions.TryGetValue(wp.SpawnName, out var p) ? p : Permission.WPSpawn;
 
                 // Check if any weapon is not allowed.
-                if (!ignoreSettingsAndPerms && loadout.Any((wp) => !IsAllowed(wp.Perm)))
+                if (loadout.Any((wp) => !IsAllowed(ResolveCurrentPerm(wp))))
                 {
                     Notify.Alert("One or more weapon(s) in this saved loadout are not allowed on this server. Those weapons will not be loaded.");
                 }
@@ -2842,7 +2847,7 @@ namespace vMenuClient
                         continue;
                     }
 
-                    if (ignoreSettingsAndPerms || IsAllowed(w.Perm))
+                    if (IsAllowed(ResolveCurrentPerm(w)))
                     {
                         // Give the weapon
                         GiveWeaponToPed(Game.PlayerPed.Handle, w.Hash, w.CurrentAmmo > -1 ? w.CurrentAmmo : w.GetMaxAmmo, false, false);


### PR DESCRIPTION
Loadouts weren't checking weapon permissions at all. It passed ignoreSettingsAndPerms=true,  Permission enum values change as new weapons are added, so, a loadout saved by an older vMenu build could deserialize to the wrong permission. Resolve permissions fresh from the weapon's SpawnName instead of using the saved value.