### PR TITLE
fix(vehicle): don't show replace vehicle option when disallowed

### DIFF
--- a/vMenu/menus/VehicleSpawner.cs
+++ b/vMenu/menus/VehicleSpawner.cs
@@ -43,7 +43,10 @@ namespace vMenuClient.menus
                 menu.AddMenuItem(spawnByName);
             }
             menu.AddMenuItem(spawnInVeh);
-            menu.AddMenuItem(replacePrev);
+            if (IsAllowed(Permission.VSDisableReplacePrevious))
+            {
+                menu.AddMenuItem(replacePrev);
+            }
             #endregion
 
             #region addon cars menu


### PR DESCRIPTION
Hides the 'Replace Previous Vehicle' option from the menu when it's been disallowed.