### PR TITLE
perf(world): resolve the weather schedule with a binary search

### DIFF
--- a/src/Shared/vMenu.Enhanced.Data/World/WeatherCycle.cs
+++ b/src/Shared/vMenu.Enhanced.Data/World/WeatherCycle.cs
@@ -215,46 +215,86 @@ public static class WeatherCycle
         new(381, WeatherType.Smog),
     ];
 
+    /// <summary>Where the next different type starts, per entry, or -1 if the table holds only one.</summary>
+    // Declared after Entries because a static initialiser reads the fields above it, and built once
+    // rather than walked per resolve: the walk it replaces ran on every call only to skip repeats.
+    private static readonly int[] NextDifferent = BuildNextDifferent();
+
     public static CycleResolution Resolve(double cycleGameHours)
     {
         var position = GameClock.Mod(cycleGameHours, GameClock.GameHoursPerCycle);
-
-        var index = Entries.Length - 1;
-
-        for (var i = 0; i < Entries.Length; i++)
-        {
-            if (Entries[i].GameHour > position)
-            {
-                index = i - 1;
-
-                break;
-            }
-        }
-
+        var index = BlockAt(position);
         var current = Entries[index].Type;
+        var nextIndex = NextDifferent[index];
 
-        // Neighbouring entries often repeat a type, so index + 1 would announce a change that never
-        // happens on screen. Skipping to the next different type spans the whole run instead.
-        for (var step = 1; step <= Entries.Length; step++)
+        if (nextIndex < 0)
         {
-            var next = Entries[(index + step) % Entries.Length];
-
-            if (next.Type == current)
-            {
-                continue;
-            }
-
-            var until = next.GameHour - position;
-
-            if (until <= 0.0)
-            {
-                until += GameClock.GameHoursPerCycle;
-            }
-
-            return new CycleResolution(current, next.Type, until);
+            return new CycleResolution(current, current, GameClock.GameHoursPerCycle);
         }
 
-        return new CycleResolution(current, current, GameClock.GameHoursPerCycle);
+        var next = Entries[nextIndex];
+        var until = next.GameHour - position;
+
+        // Negative once the next block is back round the start of the cycle.
+        if (until <= 0.0)
+        {
+            until += GameClock.GameHoursPerCycle;
+        }
+
+        return new CycleResolution(current, next.Type, until);
+    }
+
+    /// <summary>The entry in force at <paramref name="position"/>: the last one starting at or before it.</summary>
+    // A binary search over 173 entries, so eight comparisons rather than up to a hundred and seventy
+    // three. It needs the table sorted ascending and starting at hour zero, which is nothing new:
+    // Validate asserts both, and the scan this replaces was equally wrong without them.
+    private static int BlockAt(double position)
+    {
+        var low = 0;
+        var high = Entries.Length - 1;
+
+        while (low < high)
+        {
+            // Rounded up, so low always advances and a two entry range cannot spin.
+            var middle = (low + high + 1) / 2;
+
+            if (Entries[middle].GameHour <= position)
+            {
+                low = middle;
+            }
+            else
+            {
+                high = middle - 1;
+            }
+        }
+
+        return low;
+    }
+
+    // Neighbouring entries often repeat a type, so index + 1 would announce a change that never
+    // happens on screen. Skipping to the next different type spans the whole run instead.
+    private static int[] BuildNextDifferent()
+    {
+        var next = new int[Entries.Length];
+
+        for (var index = 0; index < Entries.Length; index++)
+        {
+            next[index] = -1;
+
+            for (var step = 1; step < Entries.Length; step++)
+            {
+                var candidate = (index + step) % Entries.Length;
+
+                if (Entries[candidate].Type != Entries[index].Type)
+                {
+                    next[index] = candidate;
+
+                    break;
+                }
+            }
+        }
+
+        return next;
     }
 
     /// <summary>Checks the table against every structural property the schedule is known to have.</summary>


### PR DESCRIPTION
_Research done by ClaudeAI, so take everything with a handful of salt here_

## What was slow

`WeatherCycle.Resolve` did two O(n) passes over the 173-entry cycle table on **every call**:

1. A linear scan to find the block in force — up to 173 double comparisons.
2. A second forward walk to skip runs of a repeated type and find the next *different* one.

The cost matters because of where it is called from. `WorldState.Schedule` invokes `Resolve` on
every access, and `WorldState.Weather` goes through `Schedule`. Both read like cheap accessors,
so nothing at the call site suggests that touching them costs a 173-entry table scan. Today only
the 4 Hz weather tick pays it; the first caller that reads either property per frame pays it 60
times a second, with nothing in the signature to warn them.

## What changed

`src/Shared/vMenu.Enhanced.Data/World/WeatherCycle.cs` only.

- **Binary search** (`BlockAt`) for the block index instead of the linear scan.
- **Precomputed `NextDifferent` table**, built once at type initialisation, replacing the forward
  walk with a single array read. The longest same-type run in the table is 4 entries, so this was
  a real per-call cost, not a theoretical one.

`Resolve` keeps the same signature, the same return value and no mutable state, so no call site
changes and the server-side `vmenu_clock` dump benefits too.

The binary search needs the table sorted ascending and starting at hour zero. That is not a new
precondition: `Validate()` asserts both, and the linear scan it replaces — which `break`s on the
first entry past the position — was equally wrong without them.

## Expected improvement

Both implementations were ported to C, driven by the entry table parsed from this file, and timed
over 20M calls per scenario, best of 5 runs, on a Xeon @ 2.80 GHz. The access pattern matters a
great deal here, so it is broken out rather than averaged away.

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| **Real tick pattern** — `World.Weather` @ 250 ms, 1× speed (+0.00208 h/call) | 78.5 ns | 21.7 ns | **3.6× faster** |
| Same, at 30× speed (+0.0625 h/call) | 79.7 ns | 22.5 ns | 3.5× faster |
| Worst case — position at the end of the table | 144.8 ns | 22.7 ns | 6.4× faster |
| Best case — position in the first block | 13.1 ns | 19.9 ns | **1.5× slower** |
| Uniform random positions | 86.8 ns | 71.1 ns | 1.2× faster |

Three things worth reading off that table honestly:

- **The real pattern is the sequential one.** `position` advances by a fraction of an in-game hour
  per call and stays inside the same block for minutes, so both the old scan and the new search hit
  near-perfectly predicted branches. That is the 3.6× row, and it is the one that describes what
  the tick actually does.
- **The new version loses at the very start of the cycle**, where the linear scan exits after one
  or two iterations and the binary search still does its full eight steps. The cycle spends about
  1/173 of its time there, and the old version's cost climbs linearly with position from that point
  while the new one stays flat — but the regression is real and worth knowing about.
- **Uniform random is the adversarial case**, not a realistic one: every binary search branch
  becomes a coin flip. It is included so the 3.6× is not mistaken for a universal figure.

### What that is worth in practice

Close to nothing, and that is the point.

At the current call rate — `World.Weather` at 250 ms, so 4 calls/second — a 57 ns saving per call
is **≈230 ns/second**, about 0.00002% of one core. Even the hypothetical this change is really
guarding against, a caller reading `WorldState.Weather` once per frame at 60 fps, would only save
≈3.4 µs/second.

So this is worth taking because it is free, exactly equivalent, and removes a footgun — not because
it will move a number in `resmon`. It is the same conclusion the tick-rate section below reaches
from the other direction: **this code path is not where client frame time goes.**

### Why not cache the resolution

Caching in `WorldState.Schedule` was the obvious alternative and was rejected deliberately.
`WorldState.TimeSpeed` is read live and uncached *on purpose*, so that raising the speed convar
takes effect without a restart; a resolution cached against elapsed time goes stale the moment
that convar moves. `TimeOffsetSeconds` and cycle wraparound add two more invalidation edges. That
is real bug surface in exchange for skipping a couple of double operations — and, per the numbers
above, the operations in question are worth nanoseconds. A stateless `Resolve` gets the same win
with no invalidation to get wrong.

## Why not just raise the tick delays

The alternative proposal for this path was to raise the three client world-sync ticks
(`World.Time` 50 ms, `World.Weather` 250 ms, `World.State` 500 ms) to 1000 ms. That trades visible
quality for a saving that cannot be measured:

**The rates are load-bearing, not arbitrary.** `NetworkOverrideClockTime` takes whole seconds and
*freezes the clock until the next call*, so the tick rate is the in-game clock's frame rate. GTA
runs 30 in-game seconds per real second, so the native's argument can only change every 33 ms —
50 ms is already 1.5× coarser than that floor. At 1000 ms the clock becomes a 1 Hz staircase
jumping 30 in-game seconds, stepping the sun 0.125° (a quarter of its own diameter) and snapping
every shadow with it. `TimeOptions.TransitionSeconds` defaults to **2 seconds**, so its smoothstep
sweep would drop from ~40 samples to 2 — the time-lapse becomes the instant cut its own setting
description calls jarring.

`SetWeatherTypeTransition` is an absolute set that must be re-asserted, which is also what wins
the fight against the engine's own weather progression. The schedule boundary window is
`60 / SpeedMultiplier` real seconds, so at 30× speed a 1 s tick gives the blend 2 steps instead
of 8.

**And the saving is below the noise floor.** All three ticks together are ~26 iterations and ~30
native calls per second. The same registry runs five `TickRate.PerFrame` ticks; one of those at
60 fps costs more than all three combined. If there is measurable client cost in this area, the
tick rates are not where it lives — which is why this PR goes after per-iteration cost instead.

(For context: legacy ran its weather sync at `Delay(1000)`, but with `SetWeatherTypeOvertimePersist`
— fire-and-forget, engine-driven — and `NetworkOverrideClockTime(h, m, 0)` with seconds forced to
zero. Enhanced deliberately changed both natives; `WorldTime.cs` names the second one directly:
*"Real seconds, not zero. Forcing them to zero is what made the legacy clock visibly step."*)

## Verification

- **Equivalence sweep.** Both implementations were run against the real entry table parsed from
  the source, over the full 384-hour cycle at 0.001-hour steps, plus every exact block boundary
  and each one nudged either side at five magnitudes, plus negative and multi-cycle inputs to
  exercise `GameClock.Mod`. **385,915 positions, 0 mismatches** on all three resolution fields
  (`Current`, `Next`, `GameHoursUntilNext`), compared for exact equality. The C benchmark
  re-checked equivalence over a further 2,000,000 random positions: 0 mismatches.
- Structural assertions confirmed the table is sorted, starts at hour zero, and that every
  `NextDifferent` entry points at the *first* differing type walking forward.
- ⚠️ **Not compiled, and not benchmarked on .NET.** The .NET 10 SDK host is blocked by this
  environment's network policy, so `dotnet build vMenu.Enhanced.slnx` has not been run and the
  timings above are native C as a proxy for RyuJIT output. .NET adds array bounds checks that
  RyuJIT only partly elides, so absolute nanoseconds will differ; the ratios should hold. CI needs
  to confirm the build.
- In game, `vmenu_world` and `vmenu_clock` dump the resolved schedule; current type, next type and
  "in N real minutes" should be unchanged at the same server time.
