### PR TITLE
fix(deps): #646 bump MenuAPI.FiveM to 3.2.28 to fix left aligned icons

### DIFF
--- a/vMenu/vMenuClient.csproj
+++ b/vMenu/vMenuClient.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MenuAPI.FiveM" Version="3.2.4" />
+    <PackageReference Include="MenuAPI.FiveM" Version="3.2.28" />
 
     <Reference Include="Microsoft.CSharp" />
     


### PR DESCRIPTION
Fixes #646

Left aligned menu item icons were overlapping the item text. The cause was in MenuAPI, not in vMenu.

This was already fixed on MenuAPI Enhanced. The same fix is now on MenuAPI Legacy and released as v3.2.28, so this PR just bumps the NuGet reference.

MenuAPI commit: https://github.com/TomGrobbe/MenuAPI/commit/556e5f7