### PR TITLE
Add MP2026_01 KORTZ CENTER HEIST vehicles & peds

### DIFF
--- a/vMenu/data/VehicleData.cs
+++ b/vMenu/data/VehicleData.cs
@@ -414,6 +414,7 @@ namespace vMenuClient.data
                 "INGOT",
                 "INTRUDER",
                 "LIMO2",
+                "MERULA", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "MINIMUS", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "PREMIER",
                 "PRIMO",
@@ -461,6 +462,7 @@ namespace vMenuClient.data
                 "DORADO", // CHOP SHOP (MP2023_02) DLC - Requires b3095
                 "DUBSTA",
                 "DUBSTA2",
+                "ESTRIDE", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "EVERON3", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "FQ2",
                 "GRANGER",
@@ -487,6 +489,7 @@ namespace vMenuClient.data
                 "SQUADDIE", // CAYO PERICO (MPHEIST4) DLC - Requires b2189
                 "TOROS",
                 "VIVANITE", // CHOP SHOP (MP2023_02) DLC - Requires b3095
+                "WARDEN", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "WOODLANDER", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "XLS",
                 "XLS2",
@@ -544,6 +547,7 @@ namespace vMenuClient.data
                 "DOMINATOR7", // LS TUNERS (MPTUNER) DLC - Requires b2372
                 "DOMINATOR8", // LS TUNERS (MPTUNER) DLC - Requires b2372
                 "DOMINATOR9", // CHOP SHOP (MP2023_02) DLC - Requires b3095
+                "DRIFTDOMINATOR8", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "DRIFTDOMINATOR9", // A SAFEHOUSE IN THE HILLS (MP2025_02) DLC - Requires b3717
                 "DRIFTDOMINATOR10", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
                 "DRIFTGAUNTLET4", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
@@ -691,6 +695,7 @@ namespace vMenuClient.data
                 "BUFFALO3",
                 "CALICO", // LS TUNERS (MPTUNER) DLC - Requires b2372
                 "CARBONIZZARE",
+                "CARTUCCIA", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "COMET2",
                 "COMET3",
                 "COMET4",
@@ -703,8 +708,10 @@ namespace vMenuClient.data
                 "CORSITA", // CRIMINAL ENTERPRISES (MPSUM2) DLC - Requires b2699
                 "COUREUR", // SA MERCENARIES (MP2023_01) DLC - Requires b2944
                 "CYPHER", // LS TUNERS (MPTUNER) DLC - Requires b2372
+                "DRIFTCOQUETTE", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "DRIFTCYPHER", // BOTTOM DOLLAR BOUNTIES (MP2024_01) DLC - Requires b3258
                 "DRAFTER", // CASINO AND RESORT (MPVINEWOOD) DLC - Requires b2060
+                "DRIFTELEGY", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "DRIFTEUROS", // CHOP SHOP (MP2023_02) DLC - Requires b3095
                 "DRIFTFUTO", // CHOP SHOP (MP2023_02) DLC - Requires b3095
                 "DRIFTFUTO2", // AGENTS OF SABOTAGE (MP2024_02) DLC - Requires b3407
@@ -823,6 +830,7 @@ namespace vMenuClient.data
                 "FMJ2", // A SAFEHOUSE IN THE HILLS (MP2025_02) DLC - Requires b3717
                 "FURIA", // CASINO HEIST (MPHEIST3) DLC - Requires b2060
                 "GP1",
+                "HORUS", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "IGNUS", // THE CONTRACT (MPSECURITY) DLC - Requires b2545
                 "INFERNUS",
                 "ITALIGTB",
@@ -830,6 +838,7 @@ namespace vMenuClient.data
                 "KRIEGER", // CASINO AND RESORT (MPVINEWOOD) DLC - Requires b2060
                 "LE7B",
                 "LM87", // CRIMINAL ENTERPRISES (MPSUM2) DLC - Requires b2699
+                "LRCGT", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "LUIVA", // A SAFEHOUSE IN THE HILLS (MP2025_02) DLC - Requires b3717
                 "NERO",
                 "NERO2",
@@ -858,6 +867,7 @@ namespace vMenuClient.data
                 "TYRUS",
                 "VACCA",
                 "VAGNER",
+                "VELENOGT", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "VIGILANTE",
                 "VIRTUE", // DRUG WARS (MPCHRISTMAS3) DLC - Requires b2802
                 "VISIONE",
@@ -955,6 +965,7 @@ namespace vMenuClient.data
                 "BRUTUS3",
                 "CARACARA",
                 "CARACARA2", // CASINO AND RESORT (MPVINEWOOD) DLC - Requires b2060
+                "CARACARA3", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "DLOADER",
                 "DRAUGUR", // CRIMINAL ENTERPRISES (MPSUM2) DLC - Requires b2699
                 "DRIFTL352", // MONEY FRONTS (MP2025_01) DLC - Requires b3570
@@ -1118,6 +1129,7 @@ namespace vMenuClient.data
                 "GBURRITO2",
                 "JOURNEY",
                 "JOURNEY2", // DRUG WARS (MPCHRISTMAS3) DLC - Requires b2802
+                "LAUFER", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "MINIVAN",
                 "MINIVAN2",
                 "PARADISE",
@@ -1321,6 +1333,7 @@ namespace vMenuClient.data
                 "POLICEOLD2",
                 "POLICET",
                 "POLICET3", // BOTTOM DOLLAR BOUNTIES (MP2024_01) DLC - Requires b3258
+                "POLIGNUS", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "POLIMPALER5", // BOTTOM DOLLAR BOUNTIES (MP2024_01) DLC - Requires b3258
                 "POLIMPALER6", // BOTTOM DOLLAR BOUNTIES (MP2024_01) DLC - Requires b3258
                 "POLMAV",

--- a/vMenu/data/VehicleData.cs
+++ b/vMenu/data/VehicleData.cs
@@ -1080,6 +1080,7 @@ namespace vMenuClient.data
                 "TR2", // Large Vehicle Trailer
                 "TR4", // Large Vehicle Trailer (Mission Cars)
                 "TRFLAT", // Large Flatbed Empty Trailer
+                "TRFLAT2", // KORTZ CENTER HEIST (MP2026_01) DLC - Requires b3889
                 "TRAILERS", // Container/Curtain Trailer
                 "TRAILERS4", // White Container Trailer
                 "TRAILERS2", // Box Trailer

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -1823,6 +1823,7 @@ namespace vMenuClient.menus
             ["csb_englishdave"] = "EnglishDaveCutscene",
             ["csb_englishdave_02"] = "EnglishDave02Cutscene", // mpheist4
             ["csb_faber_02 "] = "FaberCutscene", // mp2025_02
+            ["csb_faber_03 "] = "FaberCutscene", // mp2026_01
             ["csb_fos_rep"] = "FosRepCutscene",
             ["csb_g"] = "GCutscene",
             ["csb_georginacheng"] = "GeorginaChengCutscene", // mpheist3
@@ -1876,7 +1877,9 @@ namespace vMenuClient.menus
             ["csb_porndudes"] = "PornDudesCutscene",
             ["csb_prologuedriver"] = "PrologueDriverCutscene",
             ["csb_prolsec"] = "PrologueSec01Cutscene",
+            ["csb_rae"] = "CSB_Rae", // mp2026_01
             ["csb_rafdeangelis"] = "RafDeAngelisCutscene", // mp2025_01
+            ["csb_rafdeangelis_02"] = "RafDeAngelisCutscene_02", // mp2026_01
             ["csb_ramp_gang"] = "RampGangCutscene",
             ["csb_ramp_hic"] = "RampHicCutscene",
             ["csb_ramp_hipster"] = "RampHipsterCutscene",
@@ -1984,6 +1987,7 @@ namespace vMenuClient.menus
             ["ig_agent14_02"] = "Agent1402", // mp2025_01
             ["ig_agent_02"] = "Agent02", //mpsum2
             ["ig_ahronward"] = "AhronWard", // mp2023_02
+            ["ig_alec"] = "IG_Alec", // mp2026_01
             ["ig_amandatownley"] = "AmandaTownley",
             ["ig_amandatownley_02"] = "AmandaTownley02", // mp2025_02
             ["ig_andreas"] = "Andreas",
@@ -2059,6 +2063,7 @@ namespace vMenuClient.menus
             ["ig_entourage_b"] = "EntourageB", // mpsecurity
             ["ig_fabien"] = "Fabien",
             ["ig_faber_02"] = "Faber02", // mp2025_02
+            ["ig_faber_03"] = "Faber03", // mp2026_01
             ["ig_fbisuit_01"] = "FbiSuit01",
             ["ig_fibleader_01"] = "FIBLeader01", // mp2025_02
             ["ig_floyd"] = "Floyd",
@@ -2168,6 +2173,7 @@ namespace vMenuClient.menus
             ["ig_oscar_02"] = "Oscar02", // mp2024_02
             ["ig_paige"] = "Paige",
             ["ig_pernell_moss"] = "PernellMoss", // mp2023_01
+            ["ig_pernell_moss_02"] = "PernellMoss02", // mp2026_01
             ["ig_paper"] = "Paper",
             ["ig_party_promo"] = "PartyPromo", // mpsecurity
             ["ig_patricia"] = "Patricia",
@@ -2178,10 +2184,12 @@ namespace vMenuClient.menus
             ["ig_priest"] = "Priest",
             ["ig_prolsec_02"] = "PrologueSec02",
             ["ig_rafdeangelis"] = "RafDeAngelis", // mp2025_01
+            ["ig_rafdeangelis_02"] = "RafDeAngelis_02", // mp2026_01
             ["ig_ramp_gang"] = "RampGang",
             ["ig_ramp_hic"] = "RampHic",
             ["ig_ramp_hipster"] = "RampHipster",
             ["ig_ramp_mex"] = "RampMex",
+            ["ig_rae"] = "IG_Rae", // mp2026_01
             ["ig_rashcosvki"] = "Rashcosvki",
             ["ig_req_officer"] = "ReqOfficer", // mpsecurity
             ["ig_roccopelosi"] = "RoccoPelosi",
@@ -2340,6 +2348,7 @@ namespace vMenuClient.menus
             ["s_m_m_highsec_05"] = "Highsec05SMM", // mpsecurity
             ["s_m_m_highsec_06"] = "Highsec06SMM", // mp2025_02
             ["s_m_m_janitor"] = "JanitorSMM",
+            ["s_m_m_kortzsecurity_01"] = "Kortzsecurity_01",  // mp2026_01
             ["s_m_m_lathandy_01"] = "Lathandy01SMM",
             ["s_m_m_lifeinvad_01"] = "Lifeinvad01SMM",
             ["s_m_m_linecook"] = "LinecookSMM",

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -1822,8 +1822,8 @@ namespace vMenuClient.menus
             ["csb_drugdealer"] = "DrugDealerCutscene", // mptuner
             ["csb_englishdave"] = "EnglishDaveCutscene",
             ["csb_englishdave_02"] = "EnglishDave02Cutscene", // mpheist4
-            ["csb_faber_02"] = "FaberCutscene", // mp2025_02
-            ["csb_faber_03"] = "FaberCutscene_03", // mp2026_01
+            ["csb_faber_02"] = "Faber02Cutscene", // mp2025_02
+            ["csb_faber_03"] = "Faber03Cutscene", // mp2026_01
             ["csb_fos_rep"] = "FosRepCutscene",
             ["csb_g"] = "GCutscene",
             ["csb_georginacheng"] = "GeorginaChengCutscene", // mpheist3
@@ -1877,9 +1877,9 @@ namespace vMenuClient.menus
             ["csb_porndudes"] = "PornDudesCutscene",
             ["csb_prologuedriver"] = "PrologueDriverCutscene",
             ["csb_prolsec"] = "PrologueSec01Cutscene",
-            ["csb_rae"] = "CSB_Rae", // mp2026_01
+            ["csb_rae"] = "RaeCutscene", // mp2026_01
             ["csb_rafdeangelis"] = "RafDeAngelisCutscene", // mp2025_01
-            ["csb_rafdeangelis_02"] = "RafDeAngelisCutscene_02", // mp2026_01
+            ["csb_rafdeangelis_02"] = "RafDeAngelis02Cutscene", // mp2026_01
             ["csb_ramp_gang"] = "RampGangCutscene",
             ["csb_ramp_hic"] = "RampHicCutscene",
             ["csb_ramp_hipster"] = "RampHipsterCutscene",
@@ -1987,7 +1987,7 @@ namespace vMenuClient.menus
             ["ig_agent14_02"] = "Agent1402", // mp2025_01
             ["ig_agent_02"] = "Agent02", //mpsum2
             ["ig_ahronward"] = "AhronWard", // mp2023_02
-            ["ig_alec"] = "IG_Alec", // mp2026_01
+            ["ig_alec"] = "Alec", // mp2026_01
             ["ig_amandatownley"] = "AmandaTownley",
             ["ig_amandatownley_02"] = "AmandaTownley02", // mp2025_02
             ["ig_andreas"] = "Andreas",
@@ -2183,13 +2183,13 @@ namespace vMenuClient.menus
             ["ig_popov"] = "Popov",
             ["ig_priest"] = "Priest",
             ["ig_prolsec_02"] = "PrologueSec02",
+            ["ig_rae"] = "Rae", // mp2026_01
             ["ig_rafdeangelis"] = "RafDeAngelis", // mp2025_01
-            ["ig_rafdeangelis_02"] = "RafDeAngelis_02", // mp2026_01
+            ["ig_rafdeangelis_02"] = "RafDeAngelis02", // mp2026_01
             ["ig_ramp_gang"] = "RampGang",
             ["ig_ramp_hic"] = "RampHic",
             ["ig_ramp_hipster"] = "RampHipster",
             ["ig_ramp_mex"] = "RampMex",
-            ["ig_rae"] = "IG_Rae", // mp2026_01
             ["ig_rashcosvki"] = "Rashcosvki",
             ["ig_req_officer"] = "ReqOfficer", // mpsecurity
             ["ig_roccopelosi"] = "RoccoPelosi",
@@ -2348,7 +2348,7 @@ namespace vMenuClient.menus
             ["s_m_m_highsec_05"] = "Highsec05SMM", // mpsecurity
             ["s_m_m_highsec_06"] = "Highsec06SMM", // mp2025_02
             ["s_m_m_janitor"] = "JanitorSMM",
-            ["s_m_m_kortzsecurity_01"] = "Kortzsecurity_01",  // mp2026_01
+            ["s_m_m_kortzsecurity_01"] = "KortzSecurity01SMM",  // mp2026_01
             ["s_m_m_lathandy_01"] = "Lathandy01SMM",
             ["s_m_m_lifeinvad_01"] = "Lifeinvad01SMM",
             ["s_m_m_linecook"] = "LinecookSMM",

--- a/vMenu/menus/PlayerAppearance.cs
+++ b/vMenu/menus/PlayerAppearance.cs
@@ -1822,8 +1822,8 @@ namespace vMenuClient.menus
             ["csb_drugdealer"] = "DrugDealerCutscene", // mptuner
             ["csb_englishdave"] = "EnglishDaveCutscene",
             ["csb_englishdave_02"] = "EnglishDave02Cutscene", // mpheist4
-            ["csb_faber_02 "] = "FaberCutscene", // mp2025_02
-            ["csb_faber_03 "] = "FaberCutscene", // mp2026_01
+            ["csb_faber_02"] = "FaberCutscene", // mp2025_02
+            ["csb_faber_03"] = "FaberCutscene_03", // mp2026_01
             ["csb_fos_rep"] = "FosRepCutscene",
             ["csb_g"] = "GCutscene",
             ["csb_georginacheng"] = "GeorginaChengCutscene", // mpheist3

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -518,7 +518,7 @@ add_ace builtin.everyone "vMenu.WeaponOptions.All" allow
 # add_ace builtin.everyone "vMenu.WeaponOptions.SnowLauncher" allow # mp2023_02 dlc (3095)
 # add_ace builtin.everyone "vMenu.WeaponOptions.HackingDevice" allow # mp2023_02 dlc (3095)
 # add_ace builtin.everyone "vMenu.WeaponOptions.StunRod" allow # mp2024_01 dlc (3258)
-# add_ace builtin.everyone "vMenu.WeaponOptions.Newspaper" allow # MP2025_02 dlc (3258)
+# add_ace builtin.everyone "vMenu.WeaponOptions.Newspaper" allow # MP2025_02 dlc (3751)
 
 ####################################
 #       WEAPON LOADOUTS MENU       #


### PR DESCRIPTION
Add new vehicle model entries for the Kortz Center Heist (MP2026_01) DLC (e.g., MERULA, ESTRIDE, WARDEN, DRIFTDOMINATOR8, CARTUCCIA, HORUS, LRCGT, VELENOGT, CARACARA3, LAUFER, POLIGNUS) to vMenu/data/VehicleData.cs (comments note required builds). Update vMenu/menus/PlayerAppearance.cs with new cutscene/ped mappings for MP2026_01 characters (csb_faber_03, csb_rae, ig_alec, ig_faber_03, ig_rafdeangelis_02, ig_rae, ig_pernell_moss_02, s_m_m_kortzsecurity_01, etc.).